### PR TITLE
Feat: MemberId위한 MethodArgumentResolver 구현

### DIFF
--- a/src/main/java/com/example/sinitto/common/annotation/MemberId.java
+++ b/src/main/java/com/example/sinitto/common/annotation/MemberId.java
@@ -1,0 +1,11 @@
+package com.example.sinitto.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface MemberId {
+}

--- a/src/main/java/com/example/sinitto/common/config/WebConfig.java
+++ b/src/main/java/com/example/sinitto/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.example.sinitto.common.config;
+
+import com.example.sinitto.common.resolver.MemberIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberIdArgumentResolver());
+    }
+
+}

--- a/src/main/java/com/example/sinitto/common/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/com/example/sinitto/common/resolver/MemberIdArgumentResolver.java
@@ -1,0 +1,24 @@
+package com.example.sinitto.common.resolver;
+
+import com.example.sinitto.common.annotation.MemberId;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(MemberId.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("memberId");
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#8 

## 📝 작업 내용
- MemberId Annotation 구현
- MemberIdArgumentResolver class 구현
- WebConfig class 구현 후 MemberIdArgumentResolver 세팅

- 참고
    - 컨트롤러 메서드에 그냥 `@MemberId Long memberId` 을 하면 Swagger 문서에 memberId이 반영됩니다. 이를 방지하기 위해 
    - `@Parameter(hidden = true) @MemberId Long memberId` 이걸 쓰면 Swagger 문서에 반영이 안됩니다.


### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)



## ⏰ 현재 버그


## ✏ Git Close
close #8 

