### PR TITLE
Feat: 초기 Entity 구현

### DIFF
--- a/src/main/java/com/example/sinitto/SinittoApplication.java
+++ b/src/main/java/com/example/sinitto/SinittoApplication.java
@@ -2,8 +2,10 @@ package com.example.sinitto;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SinittoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/sinitto/callback/entity/Callback.java
+++ b/src/main/java/com/example/sinitto/callback/entity/Callback.java
@@ -3,6 +3,8 @@ package com.example.sinitto.callback.entity;
 import com.example.sinitto.member.entity.Senior;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -22,6 +24,7 @@ public class Callback {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "senior_id")
     @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Senior senior;
 
 }

--- a/src/main/java/com/example/sinitto/callback/entity/Callback.java
+++ b/src/main/java/com/example/sinitto/callback/entity/Callback.java
@@ -2,6 +2,7 @@ package com.example.sinitto.callback.entity;
 
 import com.example.sinitto.member.entity.Senior;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -16,9 +17,11 @@ public class Callback {
     private Long id;
     @CreatedDate
     private LocalDateTime postTime;
+    @NotNull
     private String status;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "senior_id")
+    @NotNull
     private Senior senior;
 
 }

--- a/src/main/java/com/example/sinitto/callback/entity/Callback.java
+++ b/src/main/java/com/example/sinitto/callback/entity/Callback.java
@@ -1,0 +1,24 @@
+package com.example.sinitto.callback.entity;
+
+import com.example.sinitto.member.entity.Senior;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Callback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @CreatedDate
+    private LocalDateTime postTime;
+    private String status;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "senior_id")
+    private Senior senior;
+
+}

--- a/src/main/java/com/example/sinitto/guardGuideline/entity/GuardGuideLine.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/entity/GuardGuideLine.java
@@ -3,6 +3,8 @@ package com.example.sinitto.guardGuideline.entity;
 import com.example.sinitto.member.entity.Senior;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 public class GuardGuideLine {
@@ -17,6 +19,7 @@ public class GuardGuideLine {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "senior_id")
     @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Senior senior;
 
 }

--- a/src/main/java/com/example/sinitto/guardGuideline/entity/GuardGuideLine.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/entity/GuardGuideLine.java
@@ -1,0 +1,18 @@
+package com.example.sinitto.guardGuideline.entity;
+
+import com.example.sinitto.member.entity.Senior;
+import jakarta.persistence.*;
+
+@Entity
+public class GuardGuideLine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String content;
+    private String type;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "senior_id")
+    private Senior senior;
+
+}

--- a/src/main/java/com/example/sinitto/guardGuideline/entity/GuardGuideLine.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/entity/GuardGuideLine.java
@@ -2,6 +2,7 @@ package com.example.sinitto.guardGuideline.entity;
 
 import com.example.sinitto.member.entity.Senior;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 public class GuardGuideLine {
@@ -9,10 +10,13 @@ public class GuardGuideLine {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
     private String content;
+    @NotNull
     private String type;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "senior_id")
+    @NotNull
     private Senior senior;
 
 }

--- a/src/main/java/com/example/sinitto/member/entity/Member.java
+++ b/src/main/java/com/example/sinitto/member/entity/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 public class Member {
@@ -11,9 +12,13 @@ public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
     private String name;
+    @NotNull
     private String phoneNumber;
+    @NotNull
     private String email;
+    @NotNull
     private boolean isSinitto;
 
 }

--- a/src/main/java/com/example/sinitto/member/entity/Member.java
+++ b/src/main/java/com/example/sinitto/member/entity/Member.java
@@ -1,0 +1,19 @@
+package com.example.sinitto.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String phoneNumber;
+    private String email;
+    private boolean isSinitto;
+
+}

--- a/src/main/java/com/example/sinitto/member/entity/Senior.java
+++ b/src/main/java/com/example/sinitto/member/entity/Senior.java
@@ -2,7 +2,9 @@ package com.example.sinitto.member.entity;
 
 import com.example.sinitto.guardGuideline.entity.GuardGuideLine;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -11,12 +13,15 @@ public class Senior {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
     private String name;
+    @NotNull
     private String phoneNumber;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @NotNull
     private Member member;
     @OneToMany(mappedBy = "senior")
-    private List<GuardGuideLine> guardGuideLines;
+    private List<GuardGuideLine> guardGuideLines = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/sinitto/member/entity/Senior.java
+++ b/src/main/java/com/example/sinitto/member/entity/Senior.java
@@ -2,6 +2,8 @@ package com.example.sinitto.member.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 public class Senior {
@@ -16,6 +18,7 @@ public class Senior {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
 }

--- a/src/main/java/com/example/sinitto/member/entity/Senior.java
+++ b/src/main/java/com/example/sinitto/member/entity/Senior.java
@@ -1,0 +1,22 @@
+package com.example.sinitto.member.entity;
+
+import com.example.sinitto.guardGuideline.entity.GuardGuideLine;
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+public class Senior {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String phoneNumber;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @OneToMany(mappedBy = "senior")
+    private List<GuardGuideLine> guardGuideLines;
+
+}

--- a/src/main/java/com/example/sinitto/member/entity/Senior.java
+++ b/src/main/java/com/example/sinitto/member/entity/Senior.java
@@ -1,11 +1,7 @@
 package com.example.sinitto.member.entity;
 
-import com.example.sinitto.guardGuideline.entity.GuardGuideLine;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 public class Senior {
@@ -21,7 +17,5 @@ public class Senior {
     @JoinColumn(name = "member_id")
     @NotNull
     private Member member;
-    @OneToMany(mappedBy = "senior")
-    private List<GuardGuideLine> guardGuideLines = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/sinitto/member/entity/Sinitto.java
+++ b/src/main/java/com/example/sinitto/member/entity/Sinitto.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.member.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 public class Sinitto {
@@ -8,10 +9,13 @@ public class Sinitto {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
     private String bankName;
+    @NotNull
     private String accountNumber;
     @OneToOne
     @JoinColumn(name = "member_id")
+    @NotNull
     private Member member;
 
 }

--- a/src/main/java/com/example/sinitto/member/entity/Sinitto.java
+++ b/src/main/java/com/example/sinitto/member/entity/Sinitto.java
@@ -1,0 +1,17 @@
+package com.example.sinitto.member.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Sinitto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String bankName;
+    private String accountNumber;
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/com/example/sinitto/member/entity/Sinitto.java
+++ b/src/main/java/com/example/sinitto/member/entity/Sinitto.java
@@ -2,6 +2,8 @@ package com.example.sinitto.member.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 public class Sinitto {
@@ -16,6 +18,7 @@ public class Sinitto {
     @OneToOne
     @JoinColumn(name = "member_id")
     @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
 }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -1,0 +1,17 @@
+package com.example.sinitto.point.entity;
+
+import com.example.sinitto.member.entity.Member;
+import jakarta.persistence.*;
+
+@Entity
+public class Point {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int price;
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -3,6 +3,8 @@ package com.example.sinitto.point.entity;
 import com.example.sinitto.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 public class Point {
@@ -15,6 +17,7 @@ public class Point {
     @OneToOne
     @JoinColumn(name = "member_id")
     @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
 }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -2,6 +2,7 @@ package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 public class Point {
@@ -9,9 +10,11 @@ public class Point {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
     private int price;
     @OneToOne
     @JoinColumn(name = "member_id")
+    @NotNull
     private Member member;
 
 }

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -1,0 +1,25 @@
+package com.example.sinitto.point.entity;
+
+import com.example.sinitto.member.entity.Member;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class PointLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int price;
+    @CreatedDate
+    private LocalDateTime postTime;
+    private String type;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -2,6 +2,7 @@ package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -14,12 +15,15 @@ public class PointLog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
     private int price;
     @CreatedDate
     private LocalDateTime postTime;
+    @NotNull
     private String type;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @NotNull
     private Member member;
 
 }

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -3,6 +3,8 @@ package com.example.sinitto.point.entity;
 import com.example.sinitto.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -24,6 +26,7 @@ public class PointLog {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#14 

## 📝 작업 내용
- 엔티티 속성에 `private` 적용
- 애너테이션 통일 시킴
    - `@ManyToOne`에 `(fetch = FetchType.LAZY)`가 빠진경우 등
- 회의때 한 부분
    -  SinittoApplication.java에 `@EnableJpaAuditing `하여 `@EntityListeners(AuditingEntityListener.class)` 활성화
    - 속성 구성
    - 연관관계 구성

⭐️⭐️⭐️`@NotNull` 추가 ⭐️⭐️⭐️
- `@CreatedDate` 붙은 속성은 JPA가 `@Id`처럼 자동으로 값을 넣어주기때문에 `@NotNull` 제외. 추후 생성자에서도 `postTime`같은건 제외 하면될듯합니다.


### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)


## ⏰ 현재 버그


## ✏ Git Close
#14 
