### PR TITLE
Feat: 보호자용 마이페이지와 관련된 로직 구현

### DIFF
--- a/src/main/java/com/example/sinitto/guard/controller/GuardController.java
+++ b/src/main/java/com/example/sinitto/guard/controller/GuardController.java
@@ -1,9 +1,11 @@
 package com.example.sinitto.guard.controller;
 
+import com.example.sinitto.common.annotation.MemberId;
 import com.example.sinitto.guard.dto.GuardRequest;
 import com.example.sinitto.guard.dto.GuardResponse;
 import com.example.sinitto.guard.dto.SeniorRequest;
 import com.example.sinitto.guard.dto.SeniorResponse;
+import com.example.sinitto.guard.service.GuardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -14,71 +16,72 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/guards")
-@Tag(name = "[미구현]마이페이지 - 보호자용", description = "보호자와 시니어 관련 마이페이지 API")
+@Tag(name = "마이페이지 - 보호자용", description = "보호자와 시니어 관련 마이페이지 API")
 public class GuardController {
+    private final GuardService guardService;
 
+    public GuardController(GuardService guardService){
+        this.guardService = guardService;
+    }
     @Operation(summary = "연결된 모든 시니어 정보 조회", description = "보호자가 등록한 모든 시니어의 정보를 요청합니다.")
     @GetMapping("/senior")
-    public ResponseEntity<List<SeniorResponse>> getAllSeniors() {
-        // 임시 응답
-        return ResponseEntity.ok(new ArrayList<>());
+    public ResponseEntity<List<SeniorResponse>> getAllSeniors(@MemberId Long memberId) {
+        return ResponseEntity.ok(guardService.readSeniors(memberId));
     }
 
     @Operation(summary = "연결된 특정 시니어 정보 조회", description = "보호자가 등록한 특정 시니어의 정보를 요청합니다.")
     @GetMapping("/senior/{seniorId}")
-    public ResponseEntity<SeniorResponse> getSenior(@PathVariable Long seniorId) {
+    public ResponseEntity<SeniorResponse> getSenior(@MemberId Long memberId, @PathVariable Long seniorId) {
         // 임시 응답
-        return ResponseEntity.ok(new SeniorResponse(null, null, null));
+        return ResponseEntity.ok(guardService.readOneSenior(memberId, seniorId));
     }
 
     @Operation(summary = "시니어 정보 수정", description = "시니어의 정보를 수정합니다.")
     @PutMapping("/senior/{seniorId}")
-    public ResponseEntity<String> updateSenior(@PathVariable Long seniorId, @RequestBody SeniorRequest request) {
-        // 임시 응답
+    public ResponseEntity<String> updateSenior(@MemberId Long memberId, @PathVariable Long seniorId, @RequestBody SeniorRequest seniorRequest) {
+        guardService.updateSenior(memberId, seniorId, seniorRequest);
         return ResponseEntity.ok("시니어 정보가 수정되었습니다.");
     }
 
     @Operation(summary = "시니어 추가", description = "보호자가 새로운 시니어를 등록합니다.")
     @PostMapping("/senior")
-    public ResponseEntity<String> createSenior(@RequestBody SeniorRequest request) {
-        // 임시 응답
+    public ResponseEntity<String> createSenior(@MemberId Long memberId, @RequestBody SeniorRequest seniorRequest) {
+        guardService.createSenior(memberId, seniorRequest);
         return ResponseEntity.ok("새로운 시니어가 등록되었습니다.");
     }
 
     @Operation(summary = "시니어 삭제", description = "보호자가 시니어를 등록 해제합니다.")
     @DeleteMapping("/senior/{seniorId}")
-    public ResponseEntity<String> deleteSenior(@PathVariable Long seniorId) {
-        // 임시 응답
+    public ResponseEntity<String> deleteSenior(@MemberId Long memberId, @PathVariable Long seniorId) {
+        guardService.deleteSenior(memberId, seniorId);
         return ResponseEntity.ok("시니어가 삭제되었습니다.");
     }
 
     @Operation(summary = "보호자 본인 정보 조회", description = "보호자의 본인 정보를 조회합니다.")
     @GetMapping
-    public ResponseEntity<GuardResponse> getGuardInfo() {
-        // 임시 응답
-        return ResponseEntity.ok(new GuardResponse(null, null, null));
+    public ResponseEntity<GuardResponse> getGuardInfo(@MemberId Long memberId) {
+        return ResponseEntity.ok(guardService.readGuard(memberId));
     }
 
     @Operation(summary = "보호자 본인 정보 수정", description = "보호자의 본인 정보를 수정합니다.")
     @PutMapping
-    public ResponseEntity<String> updateGuardInfo(@RequestBody GuardRequest request) {
-        // 임시 응답
+    public ResponseEntity<String> updateGuardInfo(@MemberId Long memberId, @RequestBody GuardRequest guardRequest) {
+        guardService.updateGuard(memberId, guardRequest);
         return ResponseEntity.ok("보호자 정보가 수정되었습니다.");
     }
 
-    //PASS
+    // 현재는 jwt 안의 id를 삭제하게 구현했는데, 나중에 관리자 계정 만들면 특정 id 지정해서 삭제하게 수정해야할 듯합니다.
     @Operation(summary = "보호자 삭제", description = "관리자용 API입니다.")
     @DeleteMapping
-    public ResponseEntity<String> deleteGuard() {
-        // 임시 응답
+    public ResponseEntity<String> deleteGuard(@MemberId Long memberId) {
+        guardService.deleteGuard(memberId);
         return ResponseEntity.ok("보호자가 삭제되었습니다.");
     }
 
     @Operation(summary = "모든 보호자 조회", description = "관리자용 API입니다.")
     @GetMapping("/all")
-    public ResponseEntity<List<GuardResponse>> getAllGuards() {
-        // 임시 응답
-        return ResponseEntity.ok(new ArrayList<>());
+    public ResponseEntity<List<GuardResponse>> getAllGuards(@MemberId Long memberId) {
+        return ResponseEntity.ok(guardService.readAllGuards());
     }
 
 }

--- a/src/main/java/com/example/sinitto/guard/controller/GuardController.java
+++ b/src/main/java/com/example/sinitto/guard/controller/GuardController.java
@@ -32,7 +32,6 @@ public class GuardController {
     @Operation(summary = "연결된 특정 시니어 정보 조회", description = "보호자가 등록한 특정 시니어의 정보를 요청합니다.")
     @GetMapping("/senior/{seniorId}")
     public ResponseEntity<SeniorResponse> getSenior(@MemberId Long memberId, @PathVariable Long seniorId) {
-        // 임시 응답
         return ResponseEntity.ok(guardService.readOneSenior(memberId, seniorId));
     }
 

--- a/src/main/java/com/example/sinitto/guard/controller/GuardControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/guard/controller/GuardControllerAdvice.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.net.URI;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.example.sinitto.guard")
 public class GuardControllerAdvice {
     @ExceptionHandler(SeniorNotFoundException.class)
     public ProblemDetail handleSeniorNotFoundException(SeniorNotFoundException e){

--- a/src/main/java/com/example/sinitto/guard/controller/GuardControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/guard/controller/GuardControllerAdvice.java
@@ -3,6 +3,7 @@ package com.example.sinitto.guard.controller;
 import com.example.sinitto.guard.exception.SeniorNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,11 +12,11 @@ import java.net.URI;
 @RestControllerAdvice(basePackages = "com.example.sinitto.guard")
 public class GuardControllerAdvice {
     @ExceptionHandler(SeniorNotFoundException.class)
-    public ProblemDetail handleSeniorNotFoundException(SeniorNotFoundException e){
+    public ResponseEntity<ProblemDetail> handleSeniorNotFoundException(SeniorNotFoundException e){
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
         problemDetail.setType(URI.create("/error/senior-not-found"));
         problemDetail.setTitle("Senior Not Found");
 
-        return problemDetail;
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
 }

--- a/src/main/java/com/example/sinitto/guard/controller/GuardControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/guard/controller/GuardControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.example.sinitto.guard.controller;
+
+import com.example.sinitto.guard.exception.SeniorNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice
+public class GuardControllerAdvice {
+    @ExceptionHandler(SeniorNotFoundException.class)
+    public ProblemDetail handleSeniorNotFoundException(SeniorNotFoundException e){
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setType(URI.create("/error/senior-not-found"));
+        problemDetail.setTitle("Senior Not Found");
+
+        return problemDetail;
+    }
+}

--- a/src/main/java/com/example/sinitto/guard/exception/SeniorNotFoundException.java
+++ b/src/main/java/com/example/sinitto/guard/exception/SeniorNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.guard.exception;
+
+public class SeniorNotFoundException extends RuntimeException {
+    public SeniorNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/guard/repository/SeniorRepository.java
+++ b/src/main/java/com/example/sinitto/guard/repository/SeniorRepository.java
@@ -1,0 +1,14 @@
+package com.example.sinitto.guard.repository;
+
+import com.example.sinitto.member.entity.Senior;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SeniorRepository extends JpaRepository<Senior, Long> {
+    List<Senior> findByMemberId(Long memberId);
+    Optional<Senior> findByIdAndMemberId(Long Id, Long memberId);
+}

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -1,0 +1,100 @@
+package com.example.sinitto.guard.service;
+
+import com.example.sinitto.guard.dto.GuardRequest;
+import com.example.sinitto.guard.dto.GuardResponse;
+import com.example.sinitto.guard.dto.SeniorRequest;
+import com.example.sinitto.guard.dto.SeniorResponse;
+import com.example.sinitto.guard.exception.SeniorNotFoundException;
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import com.example.sinitto.member.exception.MemberNotFoundException;
+
+import java.util.List;
+
+@Service
+public class GuardService {
+    private final MemberRepository memberRepository;
+    private final SeniorRepository seniorRepository;
+
+    public GuardService(MemberRepository memberRepository, SeniorRepository seniorRepository){
+        this.memberRepository = memberRepository;
+        this.seniorRepository = seniorRepository;
+    }
+
+    public GuardResponse readGuard(Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
+        );
+
+        return new GuardResponse(member.getName(), member.getEmail(), member.getPhoneNumber());
+    }
+
+    public void updateGuard(Long memberId, GuardRequest guardRequest){
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
+        );
+
+        member.updateMember(guardRequest.name(), guardRequest.email(), guardRequest.phoneNumber());
+        memberRepository.save(member);
+    }
+
+    public void deleteGuard(Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
+        );
+
+        memberRepository.delete(member);
+    }
+
+    public void createSenior(Long memberId, SeniorRequest seniorRequest){
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
+        );
+
+        Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
+
+        seniorRepository.save(senior);
+    }
+
+    public List<SeniorResponse> readSeniors(Long memberId){
+        List<Senior> senior = seniorRepository.findByMemberId(memberId);
+
+        return senior.stream().map(Senior::mapToResponse).toList();
+    }
+
+    public SeniorResponse readOneSenior(Long memberId, Long seniorId){
+        Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
+                () -> new SeniorNotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
+        );
+
+        return new SeniorResponse(senior.getId(), senior.getName(), senior.getPhoneNumber());
+    }
+
+    public void updateSenior(Long memberId, Long seniorId, SeniorRequest seniorRequest){
+        Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
+                () -> new SeniorNotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
+        );
+
+        senior.updateSenior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber());
+        seniorRepository.save(senior);
+    }
+
+    public void deleteSenior(Long memberId, Long seniorId){
+        Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
+                () -> new SeniorNotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
+        );
+
+        seniorRepository.delete(senior);
+    }
+
+    public List<GuardResponse> readAllGuards(){
+        List<Member> members = memberRepository.findByIsSinitto(false);
+
+        return members.stream()
+                .map(m -> new GuardResponse(m.getName(), m.getEmail(), m.getPhoneNumber()))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -11,6 +11,7 @@ import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import com.example.sinitto.member.exception.MemberNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class GuardService {
         this.seniorRepository = seniorRepository;
     }
 
+    @Transactional
     public GuardResponse readGuard(Long memberId){
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
@@ -32,15 +34,16 @@ public class GuardService {
         return new GuardResponse(member.getName(), member.getEmail(), member.getPhoneNumber());
     }
 
+    @Transactional
     public void updateGuard(Long memberId, GuardRequest guardRequest){
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
 
         member.updateMember(guardRequest.name(), guardRequest.email(), guardRequest.phoneNumber());
-        memberRepository.save(member);
     }
 
+    @Transactional
     public void deleteGuard(Long memberId){
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
@@ -49,6 +52,7 @@ public class GuardService {
         memberRepository.delete(member);
     }
 
+    @Transactional
     public void createSenior(Long memberId, SeniorRequest seniorRequest){
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
@@ -59,12 +63,14 @@ public class GuardService {
         seniorRepository.save(senior);
     }
 
+    @Transactional
     public List<SeniorResponse> readSeniors(Long memberId){
         List<Senior> senior = seniorRepository.findByMemberId(memberId);
 
         return senior.stream().map(Senior::mapToResponse).toList();
     }
 
+    @Transactional
     public SeniorResponse readOneSenior(Long memberId, Long seniorId){
         Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
                 () -> new SeniorNotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
@@ -73,15 +79,16 @@ public class GuardService {
         return new SeniorResponse(senior.getId(), senior.getName(), senior.getPhoneNumber());
     }
 
+    @Transactional
     public void updateSenior(Long memberId, Long seniorId, SeniorRequest seniorRequest){
         Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
                 () -> new SeniorNotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
         );
 
         senior.updateSenior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber());
-        seniorRepository.save(senior);
     }
 
+    @Transactional
     public void deleteSenior(Long memberId, Long seniorId){
         Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
                 () -> new SeniorNotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
@@ -90,6 +97,7 @@ public class GuardService {
         seniorRepository.delete(senior);
     }
 
+    @Transactional
     public List<GuardResponse> readAllGuards(){
         List<Member> members = memberRepository.findByIsSinitto(false);
 

--- a/src/main/java/com/example/sinitto/member/entity/Member.java
+++ b/src/main/java/com/example/sinitto/member/entity/Member.java
@@ -21,4 +21,39 @@ public class Member {
     @NotNull
     private boolean isSinitto;
 
+    public Member(String name, String phoneNumber, String email, boolean isSinitto) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+        this.isSinitto = isSinitto;
+    }
+
+    protected Member() {
+    }
+
+    public void updateMember(String name, String email, String phoneNumber){
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public boolean isSinitto() {
+        return isSinitto;
+    }
+
+    public String getEmail() {
+        return email;
+    }
 }

--- a/src/main/java/com/example/sinitto/member/entity/Senior.java
+++ b/src/main/java/com/example/sinitto/member/entity/Senior.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.member.entity;
 
+import com.example.sinitto.guard.dto.SeniorResponse;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.OnDelete;
@@ -21,4 +22,34 @@ public class Senior {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
+    public Senior(String name, String phoneNumber, Member member){
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.member = member;
+    }
+
+    public void updateSenior(String name, String phoneNumber){
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public SeniorResponse mapToResponse(){
+        return new SeniorResponse(this.id, this.name, this.phoneNumber);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public Member getMember() {
+        return member;
+    }
 }

--- a/src/main/java/com/example/sinitto/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/sinitto/member/repository/MemberRepository.java
@@ -4,12 +4,13 @@ import com.example.sinitto.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
-
     boolean existsByEmail(String email);
+    List<Member> findByIsSinitto(boolean isSinitto);
 }

--- a/src/test/java/com/example/sinitto/guard/entity/SeniorTest.java
+++ b/src/test/java/com/example/sinitto/guard/entity/SeniorTest.java
@@ -1,0 +1,52 @@
+package com.example.sinitto.guard.entity;
+
+import com.example.sinitto.guard.dto.SeniorResponse;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class SeniorTest {
+    private Member member;
+    private Senior senior;
+
+    @BeforeEach
+    void setup(){
+        member = new Member(
+                "test",
+                "01012345678",
+                "test@test.com",
+                true
+        );
+        senior = new Senior("testSenior", "01000000000", member);
+    }
+
+    @Test
+    @DisplayName("Senior 엔티티 생성자 테스트")
+    void counstructorTest(){
+        assertThat(senior.getId()).isNull();
+        assertThat(senior.getName()).isEqualTo("testSenior");
+        assertThat(senior.getPhoneNumber()).isEqualTo("01000000000");
+        assertThat(senior.getMember()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("updateSenior 메소드 테스트")
+    void updateSeniorTest(){
+        senior.updateSenior("updateSenior", "01011111111");
+        assertThat(senior.getName()).isEqualTo("updateSenior");
+        assertThat(senior.getPhoneNumber()).isEqualTo("01011111111");
+    }
+
+    @Test
+    @DisplayName("mapToResponse 메소드 테스트")
+    void mapToResponseTest(){
+        SeniorResponse response = senior.mapToResponse();
+        assertThat(response.seniorId()).isNull();
+        assertThat(response.seniorName()).isEqualTo(senior.getName());
+        assertThat(response.seniorPhoneNumber()).isEqualTo(senior.getPhoneNumber());
+    }
+}

--- a/src/test/java/com/example/sinitto/guard/repository/SeniorRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/guard/repository/SeniorRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.example.sinitto.guard.repository;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+public class SeniorRepositoryTest {
+    @Autowired
+    private SeniorRepository seniorRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("저장 테스트")
+    void saveSenior(){
+        //given
+        Member member = memberRepository.save(new Member("test", "01012345678", "test@test.com", false));
+        Senior senior = new Senior("testSenior", "01000000000", member);
+        //when
+        Senior result = seniorRepository.save(senior);
+        //then
+        assertThat(senior).isSameAs(result);
+    }
+
+    @Test
+    @DisplayName("조회 확인")
+    void readSenior(){
+        //given
+        Member member = memberRepository.save(new Member("test", "01012345678", "test@test.com", false));
+        Senior senior = seniorRepository.save(new Senior("testSenior", "01000000000", member));
+
+        //when
+        Senior result = seniorRepository.findById(senior.getId()).get();
+
+        //then
+        assertThat(senior).isSameAs(result);
+    }
+
+    @Test
+    @DisplayName("findByMemberId 메소드 테스트")
+    void findByMemberIdTest(){
+        //given
+        Member member = memberRepository.save(new Member("test", "01012345678", "test@test.com", false));
+        Senior senior = seniorRepository.save(new Senior("testSenior", "01000000000", member));
+
+        //when
+        Senior result = seniorRepository.findByMemberId(member.getId()).get(0);
+
+        //then
+        assertThat(senior).isSameAs(result);
+    }
+
+    @Test
+    @DisplayName("findByIdAndMemberId 메소드 테스트")
+    void findByIdAndMemberIdTest(){
+        //given
+        Member member = memberRepository.save(new Member("test", "01012345678", "test@test.com", false));
+        Senior senior = seniorRepository.save(new Senior("testSenior", "01000000000", member));
+
+        //when
+        Senior result = seniorRepository.findByIdAndMemberId(senior.getId(), member.getId()).get();
+
+        //then
+        assertThat(senior).isSameAs(result);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #28 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 서비스 레이어(GuardService) 구현을 위한 Senior 엔티티 수정 및 SeniorRepository 인터페이스 추가
- MemberRepository 및 SeniorRepository를 활용하여 GuardService 클래스 구현
- SeniorRepository에서 Senior를 찾지 못할 경우 발생하는 예외처리인 SeniorNotFoundException 예외 클래스 추가
- 보호자용 마이페이지 로직에서 예외처리 발생 시 이를 처리하는 GuardControllerAdvice 클래스 추가
- GuardService 클래스를 활용하여 GuardController 클래스에 있는 api 구현
- 코드 실행여부 확인 후 Entity 레이어 및 Repository 레이어에 대한 테스트 코드 작성

## 💬 리뷰 요구사항(선택)

> 아무래도 Member 엔티티와 연관되어 있는 부분이 많아 피치 않게 Member 엔티티를 수정하게 되었습니다 ㅠㅠ 혹시 로그인 로직과 관련된 클래스 파일 중 제가 수정해야 하는 파일 있으면 알려주세요!
> 현재 api에서 관리자용 api는 엔티티에 관리자용 계정이 따로 없어 보호자 삭제의 경우 jwt 안에 있는 id를 삭제하게 하였습니다. 추후에 관리자용 계정을 지정하면 이에 맞게 수정하면 될 것 같습니다.
> 추가로 모든 보호자 조회 ("/api/guards/all")에서도 관리자용 계정이 없어 조회 가능한 사용자를 따로 지정하지 않았습니다. 
> 이해되지 않는 부분이나 이상한 부분 있으시면 코멘트 남겨주시면 감사하겠습니다.


## ⏰ 현재 버그
> 테스트 코드 작성 후 모두 통과한 후에 올렸습니다.

## ✏ Git Close
> close #28 
> 
