### PR TITLE
Feat: Swagger에서 JWT 활용 기능 활성화

### DIFF
--- a/src/main/java/com/example/sinitto/auth/controller/AuthController.java
+++ b/src/main/java/com/example/sinitto/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.example.sinitto.auth.service.KakaoApiService;
 import com.example.sinitto.auth.service.TokenService;
 import com.example.sinitto.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -31,14 +32,14 @@ public class AuthController {
         this.memberService = memberService;
     }
 
-    @Operation(summary = "토큰 재발급", description = "RefreshToken으로 AccessToken과 RefreshToken을 재발급 한다.")
+    @Operation(summary = "토큰 재발급", description = "RefreshToken으로 AccessToken과 RefreshToken을 재발급 한다.", security = @SecurityRequirement(name = "JWT제외"))
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refreshToken(@RequestBody TokenRefreshRequest request) {
         TokenResponse tokenResponse = tokenService.refreshAccessToken(request.refreshToken());
         return ResponseEntity.status(HttpStatus.CREATED).body(tokenResponse);
     }
 
-    @Operation(summary = "Oauth 카카오 인증페이지 리다이렉트", description = "카카오 로그인 화면으로 이동한다.")
+    @Operation(summary = "Oauth 카카오 인증페이지 리다이렉트", description = "카카오 로그인 화면으로 이동한다.", security = @SecurityRequirement(name = "JWT제외"))
     @GetMapping("/oauth/kakao")
     public ResponseEntity<Void> redirectToKakaoAuth() {
         String url = kakaoApiService.getAuthorizationUrl();
@@ -47,7 +48,7 @@ public class AuthController {
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
-    @Operation(summary = "Oauth 카카오 로그인 콜백", description = "카카오 로그인 이후 발생하는 인가코드를 통해 AccessToken과 RefreshToken을 발급한다.")
+    @Operation(summary = "Oauth 카카오 로그인 콜백", description = "카카오 로그인 이후 발생하는 인가코드를 통해 AccessToken과 RefreshToken을 발급한다.", security = @SecurityRequirement(name = "JWT제외"))
     @GetMapping("/oauth/kakao/callback")
     public ResponseEntity<LoginResponse> kakaoCallback(@RequestParam("code") String code) {
         LoginResponse loginResponse = memberService.kakaoLogin(code);

--- a/src/main/java/com/example/sinitto/common/annotation/MemberId.java
+++ b/src/main/java/com/example/sinitto/common/annotation/MemberId.java
@@ -1,5 +1,7 @@
 package com.example.sinitto.common.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +9,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
+@Parameter(hidden = true)
 public @interface MemberId {
 }

--- a/src/main/java/com/example/sinitto/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/sinitto/common/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.example.sinitto.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,14 +14,20 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo());
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .info(apiInfo())
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
 
     private Info apiInfo() {
         return new Info()
                 .title("나만의 작은 시니또")
                 .description("아자아자 화이팅")
-                .version("0.0.1");
+                .version("0.0.2");
     }
 }

--- a/src/main/java/com/example/sinitto/member/controller/MemberController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.example.sinitto.auth.dto.RegisterResponse;
 import com.example.sinitto.member.dto.SignupRequest;
 import com.example.sinitto.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @Operation(summary = "시니또 회원가입", description = "시니또의 회원가입")
+    @Operation(summary = "시니또 회원가입", description = "시니또의 회원가입", security = @SecurityRequirement(name = "JWT제외"))
     @PostMapping("/sinitto")
     public ResponseEntity<RegisterResponse> sinittoSignup(@RequestBody SignupRequest request) {
         RegisterResponse registerResponse = memberService.registerNewMember(request.name(), request.phoneNumber(),
@@ -31,7 +32,7 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.CREATED).body(registerResponse);
     }
 
-    @Operation(summary = "보호자 회원가입", description = "보호자의 회원가입")
+    @Operation(summary = "보호자 회원가입", description = "보호자의 회원가입", security = @SecurityRequirement(name = "JWT제외"))
     @PostMapping("/guard")
     public ResponseEntity<RegisterResponse> guardSignup(@RequestBody SignupRequest request) {
         RegisterResponse registerResponse = memberService.registerNewMember(request.name(), request.phoneNumber(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
 #34 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- Authorize 버튼 활성화를 위한 설정
- Swagger 문서에 memberId 숨기기위해 `MemberId.java` 에 `@Parameter(hidden=true)` 붙임
```java
@Retention(RetentionPolicy.RUNTIME)
@Target(ElementType.PARAMETER)
@Parameter(hidden = true)  < -- 이거 추가
public @interface MemberId {
}
```
**이전**
<img width="521" alt="스크린샷 2024-10-02 22 57 57" src="https://github.com/user-attachments/assets/f513feb8-e9e2-4584-afd6-f4879733bee2">
**이후**
<img width="432" alt="스크린샷 2024-10-02 22 58 27" src="https://github.com/user-attachments/assets/6fc705f1-54ce-4274-ac29-471fa6344ab0">

- Member, Auth 도메인 에서는 JWT 제외 시키기 위한 내용 추가
    - 전역으로 `SecurityRequirement().addList("bearerAuth")`를 설정해놓음. (모든 api 에 JWT 요구하도록 설정)
    - **BUT**, Member, Auth 도메인은 JWT가 불필요 
    - Member, Auth 도메인 api에서 전역 JWT 설정해놓을 것을 피하기 위한 `security = @securityrequirement(name = "JWT제외")` 코드 추가

http://43.201.254.198:8080/swagger-ui/index.html

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

- 더 좋은 방법이나, 거슬리는게 있으시면 편히 말씀해주세요. 감사합니다!

## ⏰ 현재 버그


## ✏ Git Close
 
close #34 
