### PR TITLE
Feat: 안부전화 서비스 api 구현 (보호자, 시니또용)

### DIFF
--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -28,7 +28,7 @@ public class HelloCallController {
     @GetMapping("/{callId}")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallDetail(@PathVariable Long callId) {
         // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null));
+        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null));
     }
 
     @Operation(summary = "서비스 수락하기", description = "시니또가 안부전화 신청을 수락합니다.")
@@ -56,14 +56,14 @@ public class HelloCallController {
     @GetMapping("/reports")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallReports() {
         // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null));
+        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null));
     }
 
     @Operation(summary = "소통 보고서 상세조회", description = "보호자가 보고서 상세정보를 조회합니다.")
     @GetMapping("/reports/{reportId}")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallReportDetail(@PathVariable Long reportId) {
         // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null));
+        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null));
     }
 
     @Operation(summary = "진행중인 안부 서비스 취소 요청", description = "시니또가 진행중인 안부전화 서비스를 취소합니다.")

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -31,7 +31,7 @@ public class HelloCallController {
 
     @Operation(summary = "[시니또용] 안부 전화 서비스 전체 리스트 보기", description = "안부전화 신청정보를 페이지로 조회합니다.")
     @GetMapping("/sinittos/list")
-    public ResponseEntity<Page<HelloCallResponse>> getHelloCallListBySinitto(@PageableDefault(sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
+    public ResponseEntity<Page<HelloCallResponse>> getHelloCallListBySinitto(@PageableDefault(size = 10, sort = "helloCallId", direction = Sort.Direction.ASC) Pageable pageable) {
 
         Page<HelloCallResponse> helloCallResponses = helloCallService.readAllWaitingHelloCallsBySinitto(pageable);
 

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -6,7 +6,6 @@ import com.example.sinitto.helloCall.service.HelloCallPriceService;
 import com.example.sinitto.helloCall.service.HelloCallService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -6,6 +6,7 @@ import com.example.sinitto.helloCall.service.HelloCallPriceService;
 import com.example.sinitto.helloCall.service.HelloCallService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -57,8 +58,8 @@ public class HelloCallController {
     }
 
     @Operation(summary = "[보호자용] 안부 전화 서비스 비용 조회", description = "안부 전화 서비스의 이용 비용을 조회합니다.")
-    @GetMapping("/guards/cost")
-    public ResponseEntity<HelloCallPriceResponse> calculateHelloCallPrice(HelloCallPriceRequest helloCallPriceRequest) {
+    @PostMapping("/guards/cost")
+    public ResponseEntity<HelloCallPriceResponse> calculateHelloCallPrice(@RequestBody HelloCallPriceRequest helloCallPriceRequest) {
 
         HelloCallPriceResponse helloCallPriceResponse = helloCallPriceService.calculateHelloCallPrice(helloCallPriceRequest);
 
@@ -67,7 +68,7 @@ public class HelloCallController {
 
     @Operation(summary = "[보호자용] 안부 전화 서비스 신청하기", description = "보호자가 안부 전화 서비스를 신청합니다.")
     @PostMapping("/guards")
-    public ResponseEntity<StringMessageResponse> createHelloCallByGuard(@MemberId Long memberId, HelloCallRequest helloCallRequest) {
+    public ResponseEntity<StringMessageResponse> createHelloCallByGuard(@MemberId Long memberId, @RequestBody HelloCallRequest helloCallRequest) {
 
         helloCallService.createHelloCallByGuard(memberId, helloCallRequest);
 
@@ -76,7 +77,7 @@ public class HelloCallController {
 
     @Operation(summary = "[보호자용] 안부 전화 서비스 수정하기", description = "보호자가 안부 전화 서비스 내용을 수정합니다.")
     @PutMapping("/guards/{callId}")
-    public ResponseEntity<StringMessageResponse> updateHelloCallByGuard(@MemberId Long memberId, @PathVariable Long callId, HelloCallDetailUpdateRequest helloCallDetailUpdateRequest) {
+    public ResponseEntity<StringMessageResponse> updateHelloCallByGuard(@MemberId Long memberId, @PathVariable Long callId, @RequestBody HelloCallDetailUpdateRequest helloCallDetailUpdateRequest) {
 
         helloCallService.updateHelloCallByGuard(memberId, callId, helloCallDetailUpdateRequest);
 
@@ -119,7 +120,7 @@ public class HelloCallController {
         return ResponseEntity.ok(new StringMessageResponse("안부전화 시작 시간이 기록되었습니다."));
     }
 
-    @Operation(summary = "[시니또용] 안부전화 서비스 시작시간 기록", description = "시니또가 안부전화 시작시간을 기록합니다.")
+    @Operation(summary = "[시니또용] 안부전화 서비스 종료시간 기록", description = "시니또가 안부전화 종료시간을 기록합니다.")
     @PostMapping("/sinittos/end/{callId}")
     public ResponseEntity<StringMessageResponse> writeHelloCallEndTimeBySinitto(@MemberId Long memberId, @PathVariable Long callId) {
 

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -28,7 +28,7 @@ public class HelloCallController {
     @GetMapping("/{callId}")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallDetail(@PathVariable Long callId) {
         // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null));
+        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null, 0));
     }
 
     @Operation(summary = "서비스 수락하기", description = "시니또가 안부전화 신청을 수락합니다.")
@@ -56,14 +56,14 @@ public class HelloCallController {
     @GetMapping("/reports")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallReports() {
         // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null));
+        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null, 0));
     }
 
     @Operation(summary = "소통 보고서 상세조회", description = "보호자가 보고서 상세정보를 조회합니다.")
     @GetMapping("/reports/{reportId}")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallReportDetail(@PathVariable Long reportId) {
         // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null));
+        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null, 0));
     }
 
     @Operation(summary = "진행중인 안부 서비스 취소 요청", description = "시니또가 진행중인 안부전화 서비스를 취소합니다.")

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -1,76 +1,185 @@
 package com.example.sinitto.helloCall.controller;
 
-import com.example.sinitto.helloCall.dto.HelloCallDetailResponse;
-import com.example.sinitto.helloCall.dto.HelloCallReportRequest;
-import com.example.sinitto.helloCall.dto.HelloCallResponse;
+import com.example.sinitto.common.annotation.MemberId;
+import com.example.sinitto.helloCall.dto.*;
+import com.example.sinitto.helloCall.service.HelloCallPriceService;
+import com.example.sinitto.helloCall.service.HelloCallService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/hellocalls")
 @Tag(name = "안부전화", description = "안부 전화 서비스 관련 API")
 public class HelloCallController {
 
-    @Operation(summary = "안부 전화 서비스 전체 리스트 보기", description = "보호자가 요청한 안부전화 신청정보를 리스트로 조회합니다. 페이징 처리 됩니다.")
-    @GetMapping
-    public ResponseEntity<Page<HelloCallResponse>> getHelloCallList() {
-        // 임시 응답
-        return ResponseEntity.ok(new PageImpl<>(new ArrayList<>()));
+    private final HelloCallService helloCallService;
+    private final HelloCallPriceService helloCallPriceService;
+
+    public HelloCallController(HelloCallService helloCallService, HelloCallPriceService helloCallPriceService) {
+        this.helloCallService = helloCallService;
+        this.helloCallPriceService = helloCallPriceService;
     }
 
-    @Operation(summary = "선택한 안부 전화 서비스의 상세정보 보기", description = "안부전화 신청정보의 상세정보를 조회합니다.")
+    @Operation(summary = "[시니또용] 안부 전화 서비스 전체 리스트 보기", description = "안부전화 신청정보를 페이지로 조회합니다.")
+    @GetMapping("/sinittos/list")
+    public ResponseEntity<Page<HelloCallResponse>> getHelloCallListBySinitto(@PageableDefault(sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
+
+        Page<HelloCallResponse> helloCallResponses = helloCallService.readAllWaitingHelloCallsBySinitto(pageable);
+
+        return ResponseEntity.ok(helloCallResponses);
+    }
+
+    @Operation(summary = "[보호자용] 보호자가 신청한 안부전화 리스트 보기", description = "보호자 본인이 신청한 안부전화 리스트를 조회합니다.")
+    @GetMapping("/guards/lists")
+    public ResponseEntity<List<HelloCallResponse>> getHelloCallListByGuard(@MemberId Long memberId) {
+
+        List<HelloCallResponse> helloCallResponses = helloCallService.readAllHelloCallsByGuard(memberId);
+
+        return ResponseEntity.ok(helloCallResponses);
+    }
+
+    @Operation(summary = "[시니또, 보호자용] 선택한 안부 전화 서비스의 상세정보 보기", description = "안부전화 신청정보의 상세정보를 조회합니다.")
     @GetMapping("/{callId}")
     public ResponseEntity<HelloCallDetailResponse> getHelloCallDetail(@PathVariable Long callId) {
-        // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null, 0));
+
+        HelloCallDetailResponse helloCallDetailResponse = helloCallService.readHelloCallDetail(callId);
+
+        return ResponseEntity.ok(helloCallDetailResponse);
     }
 
-    @Operation(summary = "서비스 수락하기", description = "시니또가 안부전화 신청을 수락합니다.")
+    @Operation(summary = "[보호자용] 안부 전화 서비스 비용 조회", description = "안부 전화 서비스의 이용 비용을 조회합니다.")
+    @GetMapping("/guards/cost")
+    public ResponseEntity<HelloCallPriceResponse> calculateHelloCallPrice(HelloCallPriceRequest helloCallPriceRequest) {
+
+        HelloCallPriceResponse helloCallPriceResponse = helloCallPriceService.calculateHelloCallPrice(helloCallPriceRequest);
+
+        return ResponseEntity.ok(helloCallPriceResponse);
+    }
+
+    @Operation(summary = "[보호자용] 안부 전화 서비스 신청하기", description = "보호자가 안부 전화 서비스를 신청합니다.")
+    @PostMapping("/guards")
+    public ResponseEntity<StringMessageResponse> createHelloCallByGuard(@MemberId Long memberId, HelloCallRequest helloCallRequest) {
+
+        helloCallService.createHelloCallByGuard(memberId, helloCallRequest);
+
+        return ResponseEntity.ok(new StringMessageResponse("안부 전화 서비스가 신청되었습니다."));
+    }
+
+    @Operation(summary = "[보호자용] 안부 전화 서비스 수정하기", description = "보호자가 안부 전화 서비스 내용을 수정합니다.")
+    @PutMapping("/guards/{callId}")
+    public ResponseEntity<StringMessageResponse> updateHelloCallByGuard(@MemberId Long memberId, @PathVariable Long callId, HelloCallDetailUpdateRequest helloCallDetailUpdateRequest) {
+
+        helloCallService.updateHelloCallByGuard(memberId, callId, helloCallDetailUpdateRequest);
+
+        return ResponseEntity.ok(new StringMessageResponse("안부 전화 서비스 내용이 수정되었습니다."));
+    }
+
+    @Operation(summary = "[보호자용] 안부 전화 서비스 삭제하기", description = "보호자가 안부 전화 서비스 신청을 취소합니다.")
+    @DeleteMapping("/guards/{callId}")
+    public ResponseEntity<StringMessageResponse> deleteHelloCallByGuard(@MemberId Long memberId, @PathVariable Long callId) {
+
+        helloCallService.deleteHellCallByGuard(memberId, callId);
+
+        return ResponseEntity.ok(new StringMessageResponse("신청된 안부전화 서비스가 삭제되었습니다."));
+    }
+
+    @Operation(summary = "[시니또용] 서비스 수락하기", description = "시니또가 안부전화 신청을 수락합니다.")
     @PutMapping("/accept/{callId}")
-    public ResponseEntity<String> acceptHelloCall(@PathVariable Long callId) {
-        // 임시 응답
-        return ResponseEntity.ok("안부전화 서비스가 수락되었습니다.");
+    public ResponseEntity<StringMessageResponse> acceptHelloCall(@MemberId Long memberId, @PathVariable Long callId) {
+
+        helloCallService.acceptHelloCallBySinitto(memberId, callId);
+
+        return ResponseEntity.ok(new StringMessageResponse("안부전화 서비스가 수락되었습니다."));
     }
 
-    @Operation(summary = "소통 보고서 작성", description = "시니또가 안부전화 후에 보고서를 작성합니다.")
+    @Operation(summary = "[시니또용] 시니또가 수락한 안부전화 리스트 조회", description = "시니또가 수락한 안부전화 리스트를 조회합니다.")
+    @GetMapping("/own")
+    public ResponseEntity<List<HelloCallResponse>> readOwnHelloCallBySinitto(@MemberId Long memberId) {
+
+        List<HelloCallResponse> helloCallResponses = helloCallService.readOwnHelloCallBySinitto(memberId);
+
+        return ResponseEntity.ok(helloCallResponses);
+    }
+
+    @Operation(summary = "[시니또용] 안부전화 서비스 시작시간 기록", description = "시니또가 안부전화 시작시간을 기록합니다.")
+    @PostMapping("/sinittos/start/{callId}")
+    public ResponseEntity<StringMessageResponse> writeHelloCallStartTimeBySinitto(@MemberId Long memberId, @PathVariable Long callId) {
+
+        helloCallService.writeHelloCallStartTimeBySinitto(memberId, callId);
+
+        return ResponseEntity.ok(new StringMessageResponse("안부전화 시작 시간이 기록되었습니다."));
+    }
+
+    @Operation(summary = "[시니또용] 안부전화 서비스 시작시간 기록", description = "시니또가 안부전화 시작시간을 기록합니다.")
+    @PostMapping("/sinittos/end/{callId}")
+    public ResponseEntity<StringMessageResponse> writeHelloCallEndTimeBySinitto(@MemberId Long memberId, @PathVariable Long callId) {
+
+        helloCallService.writeHelloCallEndTimeBySinitto(memberId, callId);
+
+        return ResponseEntity.ok(new StringMessageResponse("안부전화 종료 시간이 기록되었습니다."));
+    }
+
+    @Operation(summary = "[시니또용] 소통 보고서 작성 및 완료 대기 상태 변경", description = "시니또가 최종 안부전화 후에 보고서를 작성합니다.")
     @PostMapping("/reports")
-    public ResponseEntity<String> createHelloCallReport(@RequestBody HelloCallReportRequest request) {
-        // 임시 응답
-        return ResponseEntity.ok("소통 보고서가 작성되었습니다.");
+    public ResponseEntity<StringMessageResponse> createHelloCallReport(@MemberId Long memberId, @RequestBody HelloCallReportRequest request) {
+
+        helloCallService.SendReportBySinitto(memberId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(new StringMessageResponse("소통 보고서가 작성되었습니다."));
     }
 
-    @Operation(summary = "서비스 수행 완료", description = "시니또가 안부전화 수행을 완료합니다.")
-    @PutMapping("/complete/{callId}")
-    public ResponseEntity<String> completeHelloCall(@PathVariable Long callId) {
-        // 임시 응답
-        return ResponseEntity.ok("안부전화 서비스가 완료되었습니다.");
+    @Operation(summary = "[보호자용] 완료 대기 상태 안부전화 완료 처리", description = "보호자가 완료 대기 상태인 안부전화의 상태를 완료로 변경합니다.")
+    @PostMapping("/complete/{callId}")
+    public ResponseEntity<StringMessageResponse> completeHelloCall(@MemberId Long memberId, @PathVariable Long callId) {
+
+        helloCallService.makeCompleteHelloCallByGuard(memberId, callId);
+
+        return ResponseEntity.ok(new StringMessageResponse("보호자에 의해 해당 안부전화가 완료처리 되었습니다."));
     }
 
-    @Operation(summary = "소통 보고서  조회", description = "보호자가 보고서  조회합니다.")
-    @GetMapping("/reports")
-    public ResponseEntity<HelloCallDetailResponse> getHelloCallReports() {
-        // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null, 0));
+    @Operation(summary = "[보호자용] 안부전화 타임로그 조회", description = "보호자가 안부전화를 수행한 시니또의 전화 타임로그를 리스트로 조회합니다.")
+    @GetMapping("/guards/log/{callId}")
+    public ResponseEntity<List<HelloCallTimeLogResponse>> readHelloCallTimeLogByGuard(@MemberId Long memberId, @PathVariable Long callId) {
+
+        List<HelloCallTimeLogResponse> helloCallTimeLogResponses = helloCallService.readHelloCallTimeLogByGuard(memberId, callId);
+
+        return ResponseEntity.ok(helloCallTimeLogResponses);
     }
 
-    @Operation(summary = "소통 보고서 상세조회", description = "보호자가 보고서 상세정보를 조회합니다.")
-    @GetMapping("/reports/{reportId}")
-    public ResponseEntity<HelloCallDetailResponse> getHelloCallReportDetail(@PathVariable Long reportId) {
-        // 임시 응답
-        return ResponseEntity.ok(new HelloCallDetailResponse(null, null, null, null, null, null, 0));
+
+    @Operation(summary = "[보호자용] 소통 보고서 조회", description = "보호자가 시니또가 작성한 보고서가 있다면 보고서를 조회합니다.")
+    @GetMapping("/reports/{callId}")
+    public ResponseEntity<HelloCallReportResponse> getHelloCallReportDetail(@MemberId Long memberId, @PathVariable Long callId) {
+
+        HelloCallReportResponse helloCallReportResponse = helloCallService.readHelloCallReportByGuard(memberId, callId);
+
+        return ResponseEntity.ok(helloCallReportResponse);
     }
 
-    @Operation(summary = "진행중인 안부 서비스 취소 요청", description = "시니또가 진행중인 안부전화 서비스를 취소합니다.")
+    @Operation(summary = "[시니또용] 진행중인 안부 서비스 취소 요청", description = "시니또가 진행중인 안부전화 서비스를 취소합니다. 취소시 포인트는 받을 수 없습니다.")
     @PutMapping("/cancel/{callId}")
-    public ResponseEntity<String> cancelHelloCall(@PathVariable Long callId) {
-        // 임시 응답
-        return ResponseEntity.ok("안부전화 서비스가 취소되었습니다.");
+    public ResponseEntity<StringMessageResponse> cancelHelloCall(@MemberId Long memberId, @PathVariable Long callId) {
+
+        helloCallService.cancelHelloCallBySinitto(memberId, callId);
+
+        return ResponseEntity.ok(new StringMessageResponse("안부전화 서비스가 취소되었습니다."));
     }
 
+    @Operation(summary = "[관리자용] 모든 안부전화 리포트 조회", description = "관리자가 모든 안부전화의 리포트를 조회합니다.")
+    @GetMapping("/admin/reports")
+    public ResponseEntity<List<HelloCallReportResponse>> readAllHelloCallReportByAdmin() {
+
+        List<HelloCallReportResponse> helloCallReportResponses = helloCallService.readAllHelloCallReportByAdmin();
+
+        return ResponseEntity.ok(helloCallReportResponses);
+    }
 }

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallController.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 
 @RestController
 @RequestMapping("/api/hellocalls")
-@Tag(name = "[미구현]안부전화", description = "안부 전화 서비스 관련 API")
+@Tag(name = "안부전화", description = "안부 전화 서비스 관련 API")
 public class HelloCallController {
 
     @Operation(summary = "안부 전화 서비스 전체 리스트 보기", description = "보호자가 요청한 안부전화 신청정보를 리스트로 조회합니다. 페이징 처리 됩니다.")

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallControllerAdvice.java
@@ -1,9 +1,6 @@
 package com.example.sinitto.helloCall.controller;
 
-import com.example.sinitto.helloCall.exception.HelloCallAlreadyExistsException;
-import com.example.sinitto.helloCall.exception.HelloCallNotFoundException;
-import com.example.sinitto.helloCall.exception.InvalidStatusException;
-import com.example.sinitto.helloCall.exception.TimeRuleException;
+import com.example.sinitto.helloCall.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -48,6 +45,15 @@ public class HelloCallControllerAdvice {
                 ex.getMessage());
         problemDetail.setType(URI.create("/errors/invalid-status-exception"));
         problemDetail.setTitle("Invalid Status Exception");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(CompletionConditionNotFulfilledException.class)
+    public ResponseEntity<ProblemDetail> handleCompletionConditionNotFulfilledException(CompletionConditionNotFulfilledException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+                ex.getMessage());
+        problemDetail.setType(URI.create("/errors/completion-condition-not-fulfilled"));
+        problemDetail.setTitle("Completion Condition Not Fulfilled");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallControllerAdvice.java
@@ -56,4 +56,13 @@ public class HelloCallControllerAdvice {
         problemDetail.setTitle("Completion Condition Not Fulfilled");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
     }
+
+    @ExceptionHandler(TimeLogSequenceException.class)
+    public ResponseEntity<ProblemDetail> handleTimeLogSequenceException(TimeLogSequenceException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+                ex.getMessage());
+        problemDetail.setType(URI.create("/errors/time-log-sequence-exception"));
+        problemDetail.setTitle("Time Log Sequence Exception");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
 }

--- a/src/main/java/com/example/sinitto/helloCall/controller/HelloCallControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/helloCall/controller/HelloCallControllerAdvice.java
@@ -1,0 +1,53 @@
+package com.example.sinitto.helloCall.controller;
+
+import com.example.sinitto.helloCall.exception.HelloCallAlreadyExistsException;
+import com.example.sinitto.helloCall.exception.HelloCallNotFoundException;
+import com.example.sinitto.helloCall.exception.InvalidStatusException;
+import com.example.sinitto.helloCall.exception.TimeRuleException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice(basePackages = "com.example.sinitto.helloCall")
+public class HelloCallControllerAdvice {
+
+    @ExceptionHandler(TimeRuleException.class)
+    public ResponseEntity<ProblemDetail> handleTimeRuleException(TimeRuleException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+                ex.getMessage());
+        problemDetail.setType(URI.create("/errors/time-rule-exception"));
+        problemDetail.setTitle("Time Rule Exception");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(HelloCallAlreadyExistsException.class)
+    public ResponseEntity<ProblemDetail> handleHelloCallAlreadyExistsException(HelloCallAlreadyExistsException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT,
+                ex.getMessage());
+        problemDetail.setType(URI.create("/errors/hello-call-already-exist"));
+        problemDetail.setTitle("Hello Call Already Exist");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+    }
+
+    @ExceptionHandler(HelloCallNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleHelloCallNotFoundException(HelloCallNotFoundException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND,
+                ex.getMessage());
+        problemDetail.setType(URI.create("/errors/hello-call-not-found"));
+        problemDetail.setTitle("Hello Call Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+    }
+
+    @ExceptionHandler(InvalidStatusException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidStatusException(InvalidStatusException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+                ex.getMessage());
+        problemDetail.setType(URI.create("/errors/invalid-status-exception"));
+        problemDetail.setTitle("Invalid Status Exception");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
@@ -9,7 +9,7 @@ public record HelloCallDetailResponse(
         LocalDate startDate,
         LocalDate endDate,
         List<TimeSlot> timeSlots,
-        String content,
+        String requirement,
         String seniorName,
         String seniorPhoneNumber,
         int price

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
@@ -1,20 +1,17 @@
 package com.example.sinitto.helloCall.dto;
 
-import java.time.LocalTime;
-import java.util.Date;
+import com.example.sinitto.helloCall.entity.TimeSlot;
+
+import java.time.LocalDate;
 import java.util.List;
 
 public record HelloCallDetailResponse(
-        Date startDate,
-        Date endDate,
+        LocalDate startDate,
+        LocalDate endDate,
         List<TimeSlot> timeSlots,
-        String content
+        String content,
+        String seniorName,
+        String seniorPhoneNumber,
+        int price
 ) {
-
-    public record TimeSlot(
-            String day,
-            LocalTime startTime,
-            LocalTime endTime,
-            int serviceTime) {
-    }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
@@ -1,8 +1,9 @@
 package com.example.sinitto.helloCall.dto;
 
-import com.example.sinitto.helloCall.entity.TimeSlot;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public record HelloCallDetailResponse(
@@ -14,4 +15,11 @@ public record HelloCallDetailResponse(
         String seniorPhoneNumber,
         int price
 ) {
+    public record TimeSlot(
+            String dayName,
+            @JsonFormat(pattern = "kk:mm")
+            LocalTime startTime,
+            @JsonFormat(pattern = "kk:mm")
+            LocalTime endTime) {
+    }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
@@ -10,7 +10,7 @@ public record HelloCallDetailUpdateRequest(
         List<TimeSlot> timeSlots,
         int price,
         int serviceTime,
-        String content
+        String requirement
 ) {
     public record TimeSlot(
             String day,

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
@@ -4,8 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-public record HelloCallRequest(
-        Long seniorId,
+public record HelloCallDetailUpdateRequest(
         LocalDate startDate,
         LocalDate endDate,
         List<TimeSlot> timeSlots,

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
@@ -13,7 +13,7 @@ public record HelloCallDetailUpdateRequest(
         String requirement
 ) {
     public record TimeSlot(
-            String day,
+            String dayName,
             LocalTime startTime,
             LocalTime endTime) {
     }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.example.sinitto.helloCall.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -14,7 +16,9 @@ public record HelloCallDetailUpdateRequest(
 ) {
     public record TimeSlot(
             String dayName,
+            @JsonFormat(pattern = "kk:mm")
             LocalTime startTime,
+            @JsonFormat(pattern = "kk:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
@@ -4,14 +4,11 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-public record HelloCallRequest(
-        Long seniorId,
+public record HelloCallPriceRequest(
         LocalDate startDate,
         LocalDate endDate,
         List<TimeSlot> timeSlots,
-        int price,
-        int serviceTime,
-        String content
+        int serviceTime
 ) {
     public record TimeSlot(
             String day,

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
@@ -11,7 +11,7 @@ public record HelloCallPriceRequest(
         int serviceTime
 ) {
     public record TimeSlot(
-            String day,
+            String dayName,
             LocalTime startTime,
             LocalTime endTime) {
     }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
@@ -1,5 +1,7 @@
 package com.example.sinitto.helloCall.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -12,7 +14,9 @@ public record HelloCallPriceRequest(
 ) {
     public record TimeSlot(
             String dayName,
+            @JsonFormat(pattern = "kk:mm")
             LocalTime startTime,
+            @JsonFormat(pattern = "kk:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceResponse.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.dto;
+
+public record HelloCallPriceResponse(
+        int price,
+        int totalServiceCount
+) {
+}

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportRequest.java
@@ -1,6 +1,8 @@
 package com.example.sinitto.helloCall.dto;
 
 public record HelloCallReportRequest(
+
+        Long helloCallId,
         String report
 ) {
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportRequest.java
@@ -1,20 +1,6 @@
 package com.example.sinitto.helloCall.dto;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-
 public record HelloCallReportRequest(
-        LocalDate startDate,
-        LocalDate endDate,
-        List<TimeSlot> timeSlots,
-        String content
+        String report
 ) {
-
-    public record TimeSlot(
-            String day,
-            LocalTime startTime,
-            LocalTime endTime,
-            int serviceTime) {
-    }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportRequest.java
@@ -1,12 +1,12 @@
 package com.example.sinitto.helloCall.dto;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.Date;
 import java.util.List;
 
 public record HelloCallReportRequest(
-        Date startDate,
-        Date endDate,
+        LocalDate startDate,
+        LocalDate endDate,
         List<TimeSlot> timeSlots,
         String content
 ) {

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallReportResponse.java
@@ -1,0 +1,11 @@
+package com.example.sinitto.helloCall.dto;
+
+import java.time.LocalDate;
+
+public record HelloCallReportResponse(
+        LocalDate startDate,
+        LocalDate endDate,
+        String sinittoName,
+        String report
+) {
+}

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
@@ -11,7 +11,7 @@ public record HelloCallRequest(
         List<TimeSlot> timeSlots,
         int price,
         int serviceTime,
-        String content
+        String requirement
 ) {
     public record TimeSlot(
             String day,

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
@@ -14,7 +14,7 @@ public record HelloCallRequest(
         String requirement
 ) {
     public record TimeSlot(
-            String day,
+            String dayName,
             LocalTime startTime,
             LocalTime endTime) {
     }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
@@ -1,5 +1,7 @@
 package com.example.sinitto.helloCall.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -15,7 +17,9 @@ public record HelloCallRequest(
 ) {
     public record TimeSlot(
             String dayName,
+            @JsonFormat(pattern = "kk:mm")
             LocalTime startTime,
+            @JsonFormat(pattern = "kk:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallResponse.java
@@ -1,7 +1,12 @@
 package com.example.sinitto.helloCall.dto;
 
+import com.example.sinitto.helloCall.entity.HelloCall;
+
+import java.util.List;
+
 public record HelloCallResponse(
         Long helloCallId,
         String seniorName,
-        boolean[] days) {
+        List<String> days,
+        HelloCall.Status status) {
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallTimeLogResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallTimeLogResponse.java
@@ -1,0 +1,10 @@
+package com.example.sinitto.helloCall.dto;
+
+import java.time.LocalDateTime;
+
+public record HelloCallTimeLogResponse(
+        String sinittoName,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {
+}

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallTimeResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallTimeResponse.java
@@ -1,0 +1,8 @@
+package com.example.sinitto.helloCall.dto;
+
+import java.time.LocalDateTime;
+
+public record HelloCallTimeResponse(
+        LocalDateTime DateAndTime
+) {
+}

--- a/src/main/java/com/example/sinitto/helloCall/dto/StringMessageResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/StringMessageResponse.java
@@ -1,0 +1,6 @@
+package com.example.sinitto.helloCall.dto;
+
+public record StringMessageResponse(
+        String message
+) {
+}

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -102,8 +102,16 @@ public class HelloCall {
         return sinitto;
     }
 
+    public void setSinitto(Sinitto sinitto) {
+        this.sinitto = sinitto;
+    }
+
     public String getReport() {
         return report;
+    }
+
+    public void setReport(String report) {
+        this.report = report;
     }
 
     public String getSinittoName() {
@@ -112,14 +120,6 @@ public class HelloCall {
 
     public List<HelloCallTimeLog> getHelloCallTimeLogs() {
         return helloCallTimeLogs;
-    }
-
-    public void setSinitto(Sinitto sinitto) {
-        this.sinitto = sinitto;
-    }
-
-    public void setReport(String report) {
-        this.report = report;
     }
 
     public boolean checkUnAuthorization(Member member) {
@@ -133,8 +133,14 @@ public class HelloCall {
     }
 
     public void checkSiniitoIsSame(Sinitto sinitto) {
-        if(!this.sinitto.equals(sinitto)) {
-            throw new UnauthorizedException("안부전화 서비스를 완료할 권한이 없습니다");
+        if (!this.sinitto.equals(sinitto)) {
+            throw new UnauthorizedException("안부전화 서비스 리포트를 작성할 권한이 없습니다.");
+        }
+    }
+
+    public void checkGuardIsCorrect(Member member) {
+        if (!this.senior.getMember().equals(member)) {
+            throw new UnauthorizedException("안부전화 서비스를 완료시킬 권한이 없습니다.");
         }
     }
 
@@ -147,22 +153,29 @@ public class HelloCall {
     }
 
     public void changeStatusToInProgress() {
-        if (this.status.equals(Status.IN_PROGRESS) || this.status.equals(Status.COMPLETE)) {
+        if (!this.status.equals(Status.WAITING)) {
             throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.IN_PROGRESS;
     }
 
     public void changeStatusToWaiting() {
-        if (this.status.equals(Status.WAITING) || this.status.equals(Status.COMPLETE)) {
+        if (!this.status.equals(Status.IN_PROGRESS)) {
             throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.WAITING;
     }
 
+    public void changeStatusToPendingComplete() {
+        if (!this.status.equals(Status.IN_PROGRESS)) {
+            throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 완료 대기 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
+        }
+        this.status = Status.PENDING_COMPLETE;
+    }
+
     public void changeStatusToComplete() {
-        if (this.status.equals(Status.WAITING) || this.status.equals(Status.COMPLETE)) {
-            throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 완료 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
+        if (!this.status.equals(Status.PENDING_COMPLETE)) {
+            throw new InvalidStatusException("안부전화 서비스가 완료 대기 일때만 완료 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.COMPLETE;
     }
@@ -184,6 +197,7 @@ public class HelloCall {
     public enum Status {
         WAITING,
         IN_PROGRESS,
+        PENDING_COMPLETE,
         COMPLETE
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -1,0 +1,122 @@
+package com.example.sinitto.helloCall.entity;
+
+import com.example.sinitto.helloCall.exception.InvalidStatusException;
+import com.example.sinitto.helloCall.exception.TimeRuleException;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class HelloCall {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private LocalDate startDate;
+    @NotNull
+    private LocalDate endDate;
+    @NotNull
+    private int price;
+    @NotNull
+    private int serviceTime;
+    @NotNull
+    private String content;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private HelloCall.Status status;
+
+    @OneToOne
+    @JoinColumn(name = "senior_id")
+    @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Senior senior;
+    @OneToMany(mappedBy = "helloCall", cascade = CascadeType.REMOVE)
+    private List<TimeSlot> timeSlots = new ArrayList<>();
+
+    public HelloCall(LocalDate startDate, LocalDate endDate, int price, int serviceTime, String content, Senior senior) {
+        if (startDate.isAfter(endDate)) {
+            throw new TimeRuleException("시작날짜가 종료날짜 이후일 수 없습니다.");
+        }
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.content = content;
+        this.status = Status.WAITING;
+        this.price = price;
+        this.serviceTime = serviceTime;
+        this.senior = senior;
+    }
+
+    protected HelloCall() {
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Senior getSenior() {
+        return senior;
+    }
+
+    public List<TimeSlot> getTimeSlots() {
+        return timeSlots;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public boolean checkUnAuthorization(Member member) {
+        return !this.senior.getMember().equals(member);
+    }
+
+    public void checkStatusIsWaiting() {
+        if (!this.status.equals(Status.WAITING)) {
+            throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 삭제가 가능합니다.");
+        }
+    }
+
+    public void updateHelloCall(LocalDate startDate, LocalDate endDate, int price, int serviceTime, String content) {
+        if (!this.status.equals(Status.WAITING)) {
+            throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 수정이 가능합니다.");
+        }
+        if (startDate.isAfter(endDate)) {
+            throw new TimeRuleException("시작날짜가 종료날짜 이후일 수 없습니다.");
+        }
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.serviceTime = serviceTime;
+        this.content = content;
+    }
+
+    public enum Status {
+        WAITING,
+        IN_PROGRESS,
+        COMPLETE
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -43,7 +43,7 @@ public class HelloCall {
     private Senior senior;
     @OneToMany(mappedBy = "helloCall", cascade = CascadeType.REMOVE)
     private List<TimeSlot> timeSlots = new ArrayList<>();
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "sinitto_id")
     private Sinitto sinitto;
     @OneToMany(mappedBy = "helloCall", cascade = CascadeType.REMOVE)
@@ -96,6 +96,10 @@ public class HelloCall {
 
     public int getPrice() {
         return price;
+    }
+
+    public int getServiceTime() {
+        return serviceTime;
     }
 
     public Sinitto getSinitto() {

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -144,7 +144,7 @@ public class HelloCall {
 
     public void checkGuardIsCorrect(Member member) {
         if (!this.senior.getMember().equals(member)) {
-            throw new UnauthorizedException("안부전화 서비스를 완료시킬 권한이 없습니다.");
+            throw new UnauthorizedException("해당 시니어의 안부전화를 신청한 보호자가 아닙니다.");
         }
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
@@ -28,20 +28,20 @@ public class HelloCallTimeLog {
     protected HelloCallTimeLog() {
     }
 
-    public void setStartDateAndTime(LocalDateTime startDateAndTime) {
-        this.startDateAndTime = startDateAndTime;
-    }
-
-    public void setEndDateAndTime(LocalDateTime endDateAndTime) {
-        this.endDateAndTime = endDateAndTime;
-    }
-
     public LocalDateTime getStartDateAndTime() {
         return startDateAndTime;
     }
 
+    public void setStartDateAndTime(LocalDateTime startDateAndTime) {
+        this.startDateAndTime = startDateAndTime;
+    }
+
     public LocalDateTime getEndDateAndTime() {
         return endDateAndTime;
+    }
+
+    public void setEndDateAndTime(LocalDateTime endDateAndTime) {
+        this.endDateAndTime = endDateAndTime;
     }
 
     public String getSinittoName() {

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
@@ -1,0 +1,50 @@
+package com.example.sinitto.helloCall.entity;
+
+import com.example.sinitto.member.entity.Sinitto;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class HelloCallTimeLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime startDateAndTime;
+    private LocalDateTime endDateAndTime;
+    @ManyToOne
+    @JoinColumn(name = "helloCall_id")
+    private HelloCall helloCall;
+    @OneToOne
+    @JoinColumn(name = "sinitto_id")
+    private Sinitto sinitto;
+
+    public HelloCallTimeLog(HelloCall helloCall, Sinitto sinitto) {
+        this.helloCall = helloCall;
+        this.sinitto = sinitto;
+    }
+
+    protected HelloCallTimeLog() {
+    }
+
+    public void setStartDateAndTime(LocalDateTime startDateAndTime) {
+        this.startDateAndTime = startDateAndTime;
+    }
+
+    public void setEndDateAndTime(LocalDateTime endDateAndTime) {
+        this.endDateAndTime = endDateAndTime;
+    }
+
+    public LocalDateTime getStartDateAndTime() {
+        return startDateAndTime;
+    }
+
+    public LocalDateTime getEndDateAndTime() {
+        return endDateAndTime;
+    }
+
+    public String getSinittoName() {
+        return this.sinitto.getMember().getName();
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
@@ -16,12 +16,19 @@ public class HelloCallTimeLog {
     @ManyToOne
     @JoinColumn(name = "helloCall_id")
     private HelloCall helloCall;
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "sinitto_id")
     private Sinitto sinitto;
 
     public HelloCallTimeLog(HelloCall helloCall, Sinitto sinitto) {
         this.helloCall = helloCall;
+        this.sinitto = sinitto;
+    }
+
+    public HelloCallTimeLog(HelloCall helloCall, Sinitto sinitto, LocalDateTime startDateAndTime, LocalDateTime endDateAndTime) {
+        this.helloCall = helloCall;
+        this.startDateAndTime = startDateAndTime;
+        this.endDateAndTime = endDateAndTime;
         this.sinitto = sinitto;
     }
 
@@ -46,5 +53,13 @@ public class HelloCallTimeLog {
 
     public String getSinittoName() {
         return this.sinitto.getMember().getName();
+    }
+
+    public HelloCall getHelloCall() {
+        return helloCall;
+    }
+
+    public Sinitto getSinitto() {
+        return sinitto;
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/entity/TimeSlot.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/TimeSlot.java
@@ -13,7 +13,7 @@ public class TimeSlot {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @NotNull
-    private String day;
+    private String dayName;
     @NotNull
     private LocalTime startTime;
     @NotNull
@@ -22,11 +22,11 @@ public class TimeSlot {
     @JoinColumn(name = "hellocall_id")
     private HelloCall helloCall;
 
-    public TimeSlot(String day, LocalTime startTime, LocalTime endTime, HelloCall helloCall) {
+    public TimeSlot(String dayName, LocalTime startTime, LocalTime endTime, HelloCall helloCall) {
         if (startTime.isAfter(endTime)) {
             throw new TimeRuleException("시작시간이 종료시간 이후일 수 없습니다.");
         }
-        this.day = day;
+        this.dayName = dayName;
         this.startTime = startTime;
         this.endTime = endTime;
         this.helloCall = helloCall;
@@ -36,8 +36,20 @@ public class TimeSlot {
 
     }
 
-    public String getDay() {
-        return day;
+    public String getDayName() {
+        return dayName;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public HelloCall getHelloCall() {
+        return helloCall;
     }
 
     public void updateTimeSlot(LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/com/example/sinitto/helloCall/entity/TimeSlot.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/TimeSlot.java
@@ -1,0 +1,50 @@
+package com.example.sinitto.helloCall.entity;
+
+import com.example.sinitto.helloCall.exception.TimeRuleException;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalTime;
+
+@Entity
+public class TimeSlot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private String day;
+    @NotNull
+    private LocalTime startTime;
+    @NotNull
+    private LocalTime endTime;
+    @ManyToOne
+    @JoinColumn(name = "hellocall_id")
+    private HelloCall helloCall;
+
+    public TimeSlot(String day, LocalTime startTime, LocalTime endTime, HelloCall helloCall) {
+        if (startTime.isAfter(endTime)) {
+            throw new TimeRuleException("시작시간이 종료시간 이후일 수 없습니다.");
+        }
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.helloCall = helloCall;
+    }
+
+    protected TimeSlot() {
+
+    }
+
+    public String getDay() {
+        return day;
+    }
+
+    public void updateTimeSlot(LocalTime startTime, LocalTime endTime) {
+        if (startTime.isAfter(endTime)) {
+            throw new TimeRuleException("시작시간이 종료시간 이후일 수 없습니다.");
+        }
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/exception/CompletionConditionNotFulfilledException.java
+++ b/src/main/java/com/example/sinitto/helloCall/exception/CompletionConditionNotFulfilledException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.exception;
+
+public class CompletionConditionNotFulfilledException extends RuntimeException {
+    public CompletionConditionNotFulfilledException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/exception/HelloCallAlreadyExistsException.java
+++ b/src/main/java/com/example/sinitto/helloCall/exception/HelloCallAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.exception;
+
+public class HelloCallAlreadyExistsException extends RuntimeException {
+    public HelloCallAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/exception/HelloCallNotFoundException.java
+++ b/src/main/java/com/example/sinitto/helloCall/exception/HelloCallNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.exception;
+
+public class HelloCallNotFoundException extends RuntimeException {
+    public HelloCallNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/exception/InvalidStatusException.java
+++ b/src/main/java/com/example/sinitto/helloCall/exception/InvalidStatusException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.exception;
+
+public class InvalidStatusException extends RuntimeException {
+    public InvalidStatusException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/exception/TimeLogSequenceException.java
+++ b/src/main/java/com/example/sinitto/helloCall/exception/TimeLogSequenceException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.exception;
+
+public class TimeLogSequenceException extends RuntimeException {
+    public TimeLogSequenceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/exception/TimeRuleException.java
+++ b/src/main/java/com/example/sinitto/helloCall/exception/TimeRuleException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.helloCall.exception;
+
+public class TimeRuleException extends RuntimeException {
+    public TimeRuleException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
@@ -16,5 +16,7 @@ public interface HelloCallRepository extends JpaRepository<HelloCall, Long> {
 
     List<HelloCall> findAllBySinitto(Sinitto sinitto);
 
+    List<HelloCall> findAllBySeniorIn(List<Senior> seniors);
+
     boolean existsBySenior(Senior senior);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
@@ -2,15 +2,19 @@ package com.example.sinitto.helloCall.repository;
 
 import com.example.sinitto.helloCall.entity.HelloCall;
 import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.entity.Sinitto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface HelloCallRepository extends JpaRepository<HelloCall, Long> {
 
     Optional<HelloCall> findBySenior(Senior senior);
+
+    List<HelloCall> findAllBySinitto(Sinitto sinitto);
 
     boolean existsBySenior(Senior senior);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
@@ -18,5 +18,5 @@ public interface HelloCallRepository extends JpaRepository<HelloCall, Long> {
 
     List<HelloCall> findAllBySeniorIn(List<Senior> seniors);
 
-    boolean existsBySenior(Senior senior);
+    boolean existsBySeniorAndStatusIn(Senior senior, List<HelloCall.Status> statuses);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
@@ -1,0 +1,16 @@
+package com.example.sinitto.helloCall.repository;
+
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.member.entity.Senior;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface HelloCallRepository extends JpaRepository<HelloCall, Long> {
+
+    Optional<HelloCall> findBySenior(Senior senior);
+
+    boolean existsBySenior(Senior senior);
+}

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.helloCall.repository;
 
+import com.example.sinitto.helloCall.entity.HelloCall;
 import com.example.sinitto.helloCall.entity.HelloCallTimeLog;
 import com.example.sinitto.member.entity.Sinitto;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface HelloCallTimeLogRepository extends JpaRepository<HelloCallTimeL
     Optional<HelloCallTimeLog> findBySinittoAndAndHelloCallId(Sinitto sinitto, Long helloCallId);
 
     List<HelloCallTimeLog> findAllByHelloCallId(Long helloCallId);
+
+    Optional<HelloCallTimeLog> findTopBySinittoAndHelloCallOrderByStartDateAndTimeDesc(Sinitto sinitto, HelloCall helloCall);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 public interface HelloCallTimeLogRepository extends JpaRepository<HelloCallTimeLog, Long> {
     Optional<HelloCallTimeLog> findBySinittoAndAndHelloCallId(Sinitto sinitto, Long helloCallId);
+
     List<HelloCallTimeLog> findAllByHelloCallId(Long helloCallId);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
@@ -1,0 +1,13 @@
+package com.example.sinitto.helloCall.repository;
+
+import com.example.sinitto.helloCall.entity.HelloCallTimeLog;
+import com.example.sinitto.member.entity.Sinitto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HelloCallTimeLogRepository extends JpaRepository<HelloCallTimeLog, Long> {
+    Optional<HelloCallTimeLog> findBySinittoAndAndHelloCallId(Sinitto sinitto, Long helloCallId);
+    List<HelloCallTimeLog> findAllByHelloCallId(Long helloCallId);
+}

--- a/src/main/java/com/example/sinitto/helloCall/repository/TimeSlotRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/TimeSlotRepository.java
@@ -1,0 +1,14 @@
+package com.example.sinitto.helloCall.repository;
+
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.TimeSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
+
+    Optional<TimeSlot> findByHelloCallAndDay(HelloCall helloCall, String day);
+}

--- a/src/main/java/com/example/sinitto/helloCall/repository/TimeSlotRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/TimeSlotRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
 
-    Optional<TimeSlot> findByHelloCallAndDay(HelloCall helloCall, String day);
+    Optional<TimeSlot> findByHelloCallAndDayName(HelloCall helloCall, String dayName);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/TimeSlotRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/TimeSlotRepository.java
@@ -5,10 +5,15 @@ import com.example.sinitto.helloCall.entity.TimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
 
     Optional<TimeSlot> findByHelloCallAndDayName(HelloCall helloCall, String dayName);
+
+    void deleteAllByHelloCall(HelloCall helloCall);
+
+    List<TimeSlot> findAllByHelloCall(HelloCall helloCall);
 }

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallPriceService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallPriceService.java
@@ -1,0 +1,66 @@
+package com.example.sinitto.helloCall.service;
+
+import com.example.sinitto.helloCall.dto.HelloCallPriceRequest;
+import com.example.sinitto.helloCall.dto.HelloCallPriceResponse;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+@Service
+public class HelloCallPriceService {
+
+    private static final int PRICE_PER_ONE_MINUTE = 50;
+
+    public HelloCallPriceResponse calculateHelloCallPrice(HelloCallPriceRequest helloCallPriceRequest) {
+        int totalServiceCount = calculateTotalServiceCount(helloCallPriceRequest);
+        int serviceTime = helloCallPriceRequest.serviceTime();
+
+        int price = totalServiceCount * serviceTime * PRICE_PER_ONE_MINUTE;
+
+        return new HelloCallPriceResponse(price, totalServiceCount);
+    }
+
+    public int calculateTotalServiceCount(HelloCallPriceRequest helloCallPriceRequest) {
+        int totalServiceCount = 0;
+
+        LocalDate startDate = helloCallPriceRequest.startDate();
+        LocalDate endDate = helloCallPriceRequest.endDate();
+
+        for (HelloCallPriceRequest.TimeSlot timeSlot : helloCallPriceRequest.timeSlots()) {
+            DayOfWeek targetDayOfWeek = convertDayStringToDayOfWeek(timeSlot.day());
+            totalServiceCount += countOccurrencesOfDay(startDate, endDate, targetDayOfWeek);
+        }
+
+        return totalServiceCount;
+    }
+
+    private DayOfWeek convertDayStringToDayOfWeek(String day) {
+        return switch (day) {
+            case "월" -> DayOfWeek.MONDAY;
+            case "화" -> DayOfWeek.TUESDAY;
+            case "수" -> DayOfWeek.WEDNESDAY;
+            case "목" -> DayOfWeek.THURSDAY;
+            case "금" -> DayOfWeek.FRIDAY;
+            case "토" -> DayOfWeek.SATURDAY;
+            case "일" -> DayOfWeek.SUNDAY;
+            default -> throw new IllegalArgumentException("잘못된 day 입니다 : " + day);
+        };
+    }
+
+    private int countOccurrencesOfDay(LocalDate startDate, LocalDate endDate, DayOfWeek targetDayOfWeek) {
+        LocalDate firstOccurrence = findFirstOccurrenceOfDay(startDate, targetDayOfWeek);
+
+        int occurrences = 0;
+        for (LocalDate date = firstOccurrence; !date.isAfter(endDate); date = date.plusWeeks(1)) {
+            occurrences++;
+        }
+
+        return occurrences;
+    }
+
+    private LocalDate findFirstOccurrenceOfDay(LocalDate startDate, DayOfWeek targetDayOfWeek) {
+        int daysToAdd = (targetDayOfWeek.getValue() - startDate.getDayOfWeek().getValue() + 7) % 7;
+        return startDate.plusDays(daysToAdd);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallPriceService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallPriceService.java
@@ -28,15 +28,15 @@ public class HelloCallPriceService {
         LocalDate endDate = helloCallPriceRequest.endDate();
 
         for (HelloCallPriceRequest.TimeSlot timeSlot : helloCallPriceRequest.timeSlots()) {
-            DayOfWeek targetDayOfWeek = convertDayStringToDayOfWeek(timeSlot.day());
+            DayOfWeek targetDayOfWeek = convertDayStringToDayOfWeek(timeSlot.dayName());
             totalServiceCount += countOccurrencesOfDay(startDate, endDate, targetDayOfWeek);
         }
 
         return totalServiceCount;
     }
 
-    private DayOfWeek convertDayStringToDayOfWeek(String day) {
-        return switch (day) {
+    private DayOfWeek convertDayStringToDayOfWeek(String dayName) {
+        return switch (dayName) {
             case "월" -> DayOfWeek.MONDAY;
             case "화" -> DayOfWeek.TUESDAY;
             case "수" -> DayOfWeek.WEDNESDAY;
@@ -44,7 +44,7 @@ public class HelloCallPriceService {
             case "금" -> DayOfWeek.FRIDAY;
             case "토" -> DayOfWeek.SATURDAY;
             case "일" -> DayOfWeek.SUNDAY;
-            default -> throw new IllegalArgumentException("잘못된 day 입니다 : " + day);
+            default -> throw new IllegalArgumentException("잘못된 day 입니다 : " + dayName);
         };
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallPriceService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallPriceService.java
@@ -44,7 +44,7 @@ public class HelloCallPriceService {
             case "금" -> DayOfWeek.FRIDAY;
             case "토" -> DayOfWeek.SATURDAY;
             case "일" -> DayOfWeek.SUNDAY;
-            default -> throw new IllegalArgumentException("잘못된 day 입니다 : " + dayName);
+            default -> throw new IllegalArgumentException("잘못된 dayName 입니다 : " + dayName);
         };
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -1,0 +1,167 @@
+package com.example.sinitto.helloCall.service;
+
+import com.example.sinitto.auth.exception.UnauthorizedException;
+import com.example.sinitto.guard.exception.SeniorNotFoundException;
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.helloCall.dto.HelloCallDetailResponse;
+import com.example.sinitto.helloCall.dto.HelloCallDetailUpdateRequest;
+import com.example.sinitto.helloCall.dto.HelloCallRequest;
+import com.example.sinitto.helloCall.dto.HelloCallResponse;
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.TimeSlot;
+import com.example.sinitto.helloCall.exception.HelloCallAlreadyExistsException;
+import com.example.sinitto.helloCall.exception.HelloCallNotFoundException;
+import com.example.sinitto.helloCall.repository.HelloCallRepository;
+import com.example.sinitto.helloCall.repository.TimeSlotRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.exception.MemberNotFoundException;
+import com.example.sinitto.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class HelloCallService {
+
+    private final HelloCallRepository helloCallRepository;
+    private final TimeSlotRepository timeSlotRepository;
+    private final SeniorRepository seniorRepository;
+    private final MemberRepository memberRepository;
+
+
+    public HelloCallService(HelloCallRepository helloCallRepository, TimeSlotRepository timeSlotRepository,
+                            SeniorRepository seniorRepository, MemberRepository memberRepository) {
+        this.helloCallRepository = helloCallRepository;
+        this.timeSlotRepository = timeSlotRepository;
+        this.seniorRepository = seniorRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void createHelloCallByGuard(Long memberId, HelloCallRequest helloCallRequest) {
+        Senior senior = seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)
+                .orElseThrow(() -> new SeniorNotFoundException("시니어를 찾을 수 없습니다."));
+
+        if (helloCallRepository.existsBySenior(senior)) {
+            throw new HelloCallAlreadyExistsException("이미 해당 시니어의 안부 전화 서비스가 존재합니다.");
+        }
+
+        HelloCall helloCall = new HelloCall(helloCallRequest.startDate(), helloCallRequest.endDate(),
+                helloCallRequest.price(), helloCallRequest.serviceTime(), helloCallRequest.content(), senior);
+        HelloCall savedHelloCall = helloCallRepository.save(helloCall);
+
+        for (HelloCallRequest.TimeSlot timeSlotRequest : helloCallRequest.timeSlots()) {
+            TimeSlot timeSlot = new TimeSlot(timeSlotRequest.day(), timeSlotRequest.startTime(),
+                    timeSlotRequest.endTime(), savedHelloCall);
+            timeSlotRepository.save(timeSlot);
+        }
+    }
+
+    @Transactional
+    public List<HelloCallResponse> readAllHelloCallsByGuard(Long memberId) {
+        List<Senior> seniors = seniorRepository.findByMemberId(memberId);
+
+        List<HelloCallResponse> helloCallResponsesForGuard = new ArrayList<>();
+
+        for (Senior senior : seniors) {
+            if (helloCallRepository.existsBySenior(senior)) {
+                HelloCall helloCall = helloCallRepository.findBySenior(senior).orElseThrow(
+                        () -> new HelloCallNotFoundException("신청된 시니어의 안부전화 정보를 찾을 수 없습니다."));
+
+                HelloCallResponse response = new HelloCallResponse(helloCall.getId(), helloCall.getSenior().getName(),
+                        helloCall.getTimeSlots().stream().map(TimeSlot::getDay).toList(), helloCall.getStatus());
+
+                helloCallResponsesForGuard.add(response);
+            }
+        }
+        return helloCallResponsesForGuard;
+    }
+
+    @Transactional
+    public List<HelloCallResponse> readAllWaitingHelloCalls() {
+
+        List<HelloCallResponse> helloCallResponses = new ArrayList<>();
+
+        List<HelloCall> helloCalls = helloCallRepository.findAll();
+
+        for (HelloCall helloCall : helloCalls) {
+            if (helloCall.getStatus().equals(HelloCall.Status.WAITING)) {
+                HelloCallResponse response = new HelloCallResponse(helloCall.getId(), helloCall.getSenior().getName(),
+                        helloCall.getTimeSlots().stream().map(TimeSlot::getDay).toList(), helloCall.getStatus());
+
+                helloCallResponses.add(response);
+            }
+        }
+        return helloCallResponses;
+    }
+
+    @Transactional(readOnly = true)
+    public HelloCallDetailResponse readHelloCallDetail(Long HelloCallId) {
+        HelloCall helloCall = helloCallRepository.findById(HelloCallId)
+                .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
+
+        return new HelloCallDetailResponse(helloCall.getStartDate(), helloCall.getEndDate(),
+                helloCall.getTimeSlots(), helloCall.getContent(), helloCall.getSenior().getName(),
+                helloCall.getSenior().getPhoneNumber(), helloCall.getPrice());
+    }
+
+    @Transactional
+    public void updateHelloCallByGuard(Long memberId, Long helloCallId, HelloCallDetailUpdateRequest helloCallDetailUpdateRequest) {
+        HelloCall helloCall = helloCallRepository.findById(helloCallId)
+                .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다."));
+
+        if (helloCall.checkUnAuthorization(member)) {
+            throw new UnauthorizedException("안부전화 정보를 수정할 권한이 없습니다.");
+        }
+
+        helloCall.updateHelloCall(helloCallDetailUpdateRequest.startDate(), helloCallDetailUpdateRequest.endDate(),
+                helloCallDetailUpdateRequest.price(), helloCallDetailUpdateRequest.serviceTime(), helloCallDetailUpdateRequest.content());
+
+        updateTimeSlots(helloCall, helloCallDetailUpdateRequest.timeSlots());
+    }
+
+    private void updateTimeSlots(HelloCall helloCall, List<HelloCallDetailUpdateRequest.TimeSlot> updatedTimeSlots) {
+        List<String> updatedDays = updatedTimeSlots.stream()
+                .map(HelloCallDetailUpdateRequest.TimeSlot::day)
+                .toList();
+
+        List<TimeSlot> existingTimeSlots = new ArrayList<>(helloCall.getTimeSlots());
+
+        for (TimeSlot existingSlot : existingTimeSlots) {
+            if (!updatedDays.contains(existingSlot.getDay())) {
+                timeSlotRepository.delete(existingSlot);
+                helloCall.getTimeSlots().remove(existingSlot);
+            }
+        }
+
+        for (HelloCallDetailUpdateRequest.TimeSlot updatedSlot : updatedTimeSlots) {
+            TimeSlot timeSlot = timeSlotRepository.findByHelloCallAndDay(helloCall, updatedSlot.day())
+                    .orElse(new TimeSlot(updatedSlot.day(), updatedSlot.startTime(), updatedSlot.endTime(), helloCall));
+
+            timeSlot.updateTimeSlot(updatedSlot.startTime(), updatedSlot.endTime());
+            timeSlotRepository.save(timeSlot);
+        }
+    }
+
+    @Transactional
+    public void deleteHellCallByGuard(Long memberId, Long helloCallId) {
+        HelloCall helloCall = helloCallRepository.findById(helloCallId)
+                .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다."));
+
+        if (helloCall.checkUnAuthorization(member)) {
+            throw new UnauthorizedException("안부전화 신청을 취소할 권한이 없습니다.");
+        }
+
+        helloCall.checkStatusIsWaiting();
+        helloCallRepository.delete(helloCall);
+    }
+}

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -59,8 +59,8 @@ public class HelloCallService {
         Senior senior = seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)
                 .orElseThrow(() -> new SeniorNotFoundException("시니어를 찾을 수 없습니다."));
 
-        if (helloCallRepository.existsBySenior(senior)) {
-            throw new HelloCallAlreadyExistsException("이미 해당 시니어의 안부 전화 서비스가 존재합니다.");
+        if (helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))) {
+            throw new HelloCallAlreadyExistsException("이미 해당 시니어에게 할당되어 대기중 또는 진행중인 안부 전화 서비스가 존재합니다.");
         }
 
         HelloCall helloCall = new HelloCall(helloCallRequest.startDate(), helloCallRequest.endDate(),
@@ -111,8 +111,8 @@ public class HelloCallService {
     }
 
     @Transactional(readOnly = true)
-    public HelloCallDetailResponse readHelloCallDetail(Long HelloCallId) {
-        HelloCall helloCall = helloCallRepository.findById(HelloCallId)
+    public HelloCallDetailResponse readHelloCallDetail(Long helloCallId) {
+        HelloCall helloCall = helloCallRepository.findById(helloCallId)
                 .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
 
         List<HelloCallDetailResponse.TimeSlot> timeSlots = helloCall.getTimeSlots().stream()

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -66,7 +66,7 @@ public class HelloCallService {
         HelloCall savedHelloCall = helloCallRepository.save(helloCall);
 
         for (HelloCallRequest.TimeSlot timeSlotRequest : helloCallRequest.timeSlots()) {
-            TimeSlot timeSlot = new TimeSlot(timeSlotRequest.day(), timeSlotRequest.startTime(),
+            TimeSlot timeSlot = new TimeSlot(timeSlotRequest.dayName(), timeSlotRequest.startTime(),
                     timeSlotRequest.endTime(), savedHelloCall);
             timeSlotRepository.save(timeSlot);
         }
@@ -84,7 +84,7 @@ public class HelloCallService {
                         () -> new HelloCallNotFoundException("신청된 시니어의 안부전화 정보를 찾을 수 없습니다."));
 
                 HelloCallResponse response = new HelloCallResponse(helloCall.getId(), helloCall.getSenior().getName(),
-                        helloCall.getTimeSlots().stream().map(TimeSlot::getDay).toList(), helloCall.getStatus());
+                        helloCall.getTimeSlots().stream().map(TimeSlot::getDayName).toList(), helloCall.getStatus());
 
                 helloCallResponsesForGuard.add(response);
             }
@@ -101,7 +101,7 @@ public class HelloCallService {
                 .filter(helloCall -> helloCall.getStatus().equals(HelloCall.Status.WAITING))
                 .map(helloCall -> new HelloCallResponse(
                         helloCall.getId(), helloCall.getSenior().getName(),
-                        helloCall.getTimeSlots().stream().map(TimeSlot::getDay).toList(), helloCall.getStatus()
+                        helloCall.getTimeSlots().stream().map(TimeSlot::getDayName).toList(), helloCall.getStatus()
                 )).toList();
 
         int totalElements = helloCallResponses.size();
@@ -143,21 +143,21 @@ public class HelloCallService {
 
     private void updateTimeSlots(HelloCall helloCall, List<HelloCallDetailUpdateRequest.TimeSlot> updatedTimeSlots) {
         List<String> updatedDays = updatedTimeSlots.stream()
-                .map(HelloCallDetailUpdateRequest.TimeSlot::day)
+                .map(HelloCallDetailUpdateRequest.TimeSlot::dayName)
                 .toList();
 
         List<TimeSlot> existingTimeSlots = new ArrayList<>(helloCall.getTimeSlots());
 
         for (TimeSlot existingSlot : existingTimeSlots) {
-            if (!updatedDays.contains(existingSlot.getDay())) {
+            if (!updatedDays.contains(existingSlot.getDayName())) {
                 timeSlotRepository.delete(existingSlot);
                 helloCall.getTimeSlots().remove(existingSlot);
             }
         }
 
         for (HelloCallDetailUpdateRequest.TimeSlot updatedSlot : updatedTimeSlots) {
-            TimeSlot timeSlot = timeSlotRepository.findByHelloCallAndDay(helloCall, updatedSlot.day())
-                    .orElse(new TimeSlot(updatedSlot.day(), updatedSlot.startTime(), updatedSlot.endTime(), helloCall));
+            TimeSlot timeSlot = timeSlotRepository.findByHelloCallAndDayName(helloCall, updatedSlot.dayName())
+                    .orElse(new TimeSlot(updatedSlot.dayName(), updatedSlot.startTime(), updatedSlot.endTime(), helloCall));
 
             timeSlot.updateTimeSlot(updatedSlot.startTime(), updatedSlot.endTime());
             timeSlotRepository.save(timeSlot);
@@ -337,7 +337,7 @@ public class HelloCallService {
 
         for (HelloCall helloCall : helloCalls) {
             HelloCallResponse response = new HelloCallResponse(helloCall.getId(), helloCall.getSenior().getName(),
-                    helloCall.getTimeSlots().stream().map(TimeSlot::getDay).toList(), helloCall.getStatus());
+                    helloCall.getTimeSlots().stream().map(TimeSlot::getDayName).toList(), helloCall.getStatus());
             helloCallResponses.add(response);
         }
 

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -78,20 +78,15 @@ public class HelloCallService {
     public List<HelloCallResponse> readAllHelloCallsByGuard(Long memberId) {
         List<Senior> seniors = seniorRepository.findByMemberId(memberId);
 
-        List<HelloCallResponse> helloCallResponsesForGuard = new ArrayList<>();
+        List<HelloCall> helloCalls = helloCallRepository.findAllBySeniorIn(seniors);
 
-        for (Senior senior : seniors) {
-            if (helloCallRepository.existsBySenior(senior)) {
-                HelloCall helloCall = helloCallRepository.findBySenior(senior).orElseThrow(
-                        () -> new HelloCallNotFoundException("신청된 시니어의 안부전화 정보를 찾을 수 없습니다."));
-
-                HelloCallResponse response = new HelloCallResponse(helloCall.getId(), helloCall.getSenior().getName(),
-                        helloCall.getTimeSlots().stream().map(TimeSlot::getDayName).toList(), helloCall.getStatus());
-
-                helloCallResponsesForGuard.add(response);
-            }
-        }
-        return helloCallResponsesForGuard;
+        return helloCalls.stream()
+                .map(helloCall -> new HelloCallResponse(
+                        helloCall.getId(),
+                        helloCall.getSenior().getName(),
+                        helloCall.getTimeSlots().stream().map(TimeSlot::getDayName).toList(),
+                        helloCall.getStatus()))
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -118,8 +118,12 @@ public class HelloCallService {
         HelloCall helloCall = helloCallRepository.findById(HelloCallId)
                 .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
 
+        List<HelloCallDetailResponse.TimeSlot> timeSlots = helloCall.getTimeSlots().stream()
+                .map(timeSlot -> new HelloCallDetailResponse.TimeSlot(
+                        timeSlot.getDayName(), timeSlot.getStartTime(), timeSlot.getEndTime())).toList();
+
         return new HelloCallDetailResponse(helloCall.getStartDate(), helloCall.getEndDate(),
-                helloCall.getTimeSlots(), helloCall.getRequirement(), helloCall.getSenior().getName(),
+                timeSlots, helloCall.getRequirement(), helloCall.getSenior().getName(),
                 helloCall.getSenior().getPhoneNumber(), helloCall.getPrice());
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -143,25 +143,13 @@ public class HelloCallService {
     }
 
     private void updateTimeSlots(HelloCall helloCall, List<HelloCallDetailUpdateRequest.TimeSlot> updatedTimeSlots) {
-        List<String> updatedDays = updatedTimeSlots.stream()
-                .map(HelloCallDetailUpdateRequest.TimeSlot::dayName)
-                .toList();
-
-        List<TimeSlot> existingTimeSlots = new ArrayList<>(helloCall.getTimeSlots());
-
-        for (TimeSlot existingSlot : existingTimeSlots) {
-            if (!updatedDays.contains(existingSlot.getDayName())) {
-                timeSlotRepository.delete(existingSlot);
-                helloCall.getTimeSlots().remove(existingSlot);
-            }
-        }
+        timeSlotRepository.deleteAllByHelloCall(helloCall);
+        helloCall.getTimeSlots().clear();
 
         for (HelloCallDetailUpdateRequest.TimeSlot updatedSlot : updatedTimeSlots) {
-            TimeSlot timeSlot = timeSlotRepository.findByHelloCallAndDayName(helloCall, updatedSlot.dayName())
-                    .orElse(new TimeSlot(updatedSlot.dayName(), updatedSlot.startTime(), updatedSlot.endTime(), helloCall));
-
-            timeSlot.updateTimeSlot(updatedSlot.startTime(), updatedSlot.endTime());
-            timeSlotRepository.save(timeSlot);
+            TimeSlot newTimeSlot = new TimeSlot(updatedSlot.dayName(), updatedSlot.startTime(), updatedSlot.endTime(), helloCall);
+            timeSlotRepository.save(newTimeSlot);
+            helloCall.getTimeSlots().add(newTimeSlot);
         }
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -211,12 +211,13 @@ public class HelloCallService {
 
     @Transactional(readOnly = true)
     public HelloCallReportResponse readHelloCallReportByGuard(Long memberId, Long helloCallId) {
-        if (!sinittoRepository.existsByMemberId(memberId)) {
-            throw new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다.");
-        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다."));
 
         HelloCall helloCall = helloCallRepository.findById(helloCallId)
                 .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
+
+        helloCall.checkGuardIsCorrect(member);
 
         if (!helloCall.checkReportIsNotNull()) {
             throw new CompletionConditionNotFulfilledException("아직 안부전화 서비스가 완료되지 않았습니다.");

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -241,7 +241,7 @@ public class HelloCallService {
 
 
     @Transactional(readOnly = true)
-    public List<HelloCallReportResponse> readAllHelloCallReport() {
+    public List<HelloCallReportResponse> readAllHelloCallReportByAdmin() {
         List<HelloCall> helloCalls = helloCallRepository.findAll();
 
         List<HelloCallReportResponse> helloCallReportResponses = new ArrayList<>();
@@ -310,8 +310,8 @@ public class HelloCallService {
     }
 
     @Transactional
-    public void SendReportBySinitto(Long memberId, Long helloCallId, HelloCallReportRequest helloCallReportRequest) {
-        HelloCall helloCall = helloCallRepository.findById(helloCallId)
+    public void SendReportBySinitto(Long memberId, HelloCallReportRequest helloCallReportRequest) {
+        HelloCall helloCall = helloCallRepository.findById(helloCallReportRequest.helloCallId())
                 .orElseThrow(() -> new HelloCallNotFoundException("id에 해당하는 안부전화 정보를 찾을 수 없습니다."));
 
         Sinitto sinitto = sinittoRepository.findByMemberId(memberId)

--- a/src/main/java/com/example/sinitto/member/entity/Senior.java
+++ b/src/main/java/com/example/sinitto/member/entity/Senior.java
@@ -28,6 +28,10 @@ public class Senior {
         this.member = member;
     }
 
+    protected Senior() {
+
+    }
+
     public void updateSenior(String name, String phoneNumber) {
         this.name = name;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/com/example/sinitto/review/controller/ReviewController.java
+++ b/src/main/java/com/example/sinitto/review/controller/ReviewController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/example/sinitto/review/controller/ReviewController.java
+++ b/src/main/java/com/example/sinitto/review/controller/ReviewController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/example/sinitto/review/entity/Review.java
+++ b/src/main/java/com/example/sinitto/review/entity/Review.java
@@ -14,18 +14,24 @@ import java.time.LocalDate;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Review {
-    @NotNull
-    int starCountForRequest;
-    @NotNull
-    int starCountForService;
-    @NotNull
-    int starCountForSatisfaction;
-    @CreatedDate
-    LocalDate postDate;
-    String content;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @NotNull
+    int starCountForRequest;
+
+    @NotNull
+    int starCountForService;
+
+    @NotNull
+    int starCountForSatisfaction;
+
+    @CreatedDate
+    LocalDate postDate;
+
+    String content;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull

--- a/src/main/java/com/example/sinitto/review/entity/Review.java
+++ b/src/main/java/com/example/sinitto/review/entity/Review.java
@@ -14,24 +14,18 @@ import java.time.LocalDate;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Review {
+    @NotNull
+    int starCountForRequest;
+    @NotNull
+    int starCountForService;
+    @NotNull
+    int starCountForSatisfaction;
+    @CreatedDate
+    LocalDate postDate;
+    String content;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @NotNull
-    int starCountForRequest;
-
-    @NotNull
-    int starCountForService;
-
-    @NotNull
-    int starCountForSatisfaction;
-
-    @CreatedDate
-    LocalDate postDate;
-
-    String content;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull

--- a/src/main/java/com/example/sinitto/sinitto/repository/SinittoRepository.java
+++ b/src/main/java/com/example/sinitto/sinitto/repository/SinittoRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface SinittoRepository extends JpaRepository<Sinitto, Long> {
     Optional<Sinitto> findByMemberId(Long memberId);
 
+    boolean existsByMemberId(Long memberId);
+
 }

--- a/src/test/java/com/example/sinitto/hellocall/entity/HelloCallTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/entity/HelloCallTest.java
@@ -1,0 +1,124 @@
+package com.example.sinitto.hellocall.entity;
+
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.exception.InvalidStatusException;
+import com.example.sinitto.helloCall.exception.TimeRuleException;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HelloCallTest {
+
+    private HelloCall helloCall;
+    private Senior senior;
+
+    @BeforeEach
+    void setup() {
+        Member member = new Member("보호자", "01033334444", "test@test.coom", false);
+        senior = new Senior("시니어", "01011112222", member);
+        helloCall = new HelloCall(
+                LocalDate.of(2024, 10, 1),
+                LocalDate.of(2024, 10, 10),
+                10000,
+                30,
+                "Hello Call Requirement",
+                senior
+        );
+    }
+
+    @Test
+    @DisplayName("HelloCall 생성자 테스트")
+    void constructorTest() {
+        assertThat(helloCall.getId()).isNull();
+        assertThat(helloCall.getStartDate()).isEqualTo(LocalDate.of(2024, 10, 1));
+        assertThat(helloCall.getEndDate()).isEqualTo(LocalDate.of(2024, 10, 10));
+        assertThat(helloCall.getPrice()).isEqualTo(10000);
+        assertThat(helloCall.getServiceTime()).isEqualTo(30);
+        assertThat(helloCall.getRequirement()).isEqualTo("Hello Call Requirement");
+        assertThat(helloCall.getStatus()).isEqualTo(HelloCall.Status.WAITING);
+        assertThat(helloCall.getSenior()).isEqualTo(senior);
+    }
+
+    @Test
+    @DisplayName("시작날짜가 종료날짜 이후일 때 예외 발생 테스트")
+    void constructorThrowsTimeRuleException() {
+        assertThatThrownBy(() -> new HelloCall(
+                LocalDate.of(2024, 10, 11),
+                LocalDate.of(2024, 10, 10),
+                10000,
+                30,
+                "Invalid Requirement",
+                senior
+        )).isInstanceOf(TimeRuleException.class)
+                .hasMessage("시작날짜가 종료날짜 이후일 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("상태 변경 테스트")
+    void changeStatusTest() {
+        helloCall.changeStatusToInProgress();
+        assertThat(helloCall.getStatus()).isEqualTo(HelloCall.Status.IN_PROGRESS);
+
+        helloCall.changeStatusToPendingComplete();
+        assertThat(helloCall.getStatus()).isEqualTo(HelloCall.Status.PENDING_COMPLETE);
+
+        helloCall.changeStatusToComplete();
+        assertThat(helloCall.getStatus()).isEqualTo(HelloCall.Status.COMPLETE);
+    }
+
+    @Test
+    @DisplayName("상태 변경 예외 발생 테스트")
+    void changeStatusThrowsInvalidStatusException() {
+        helloCall.changeStatusToInProgress();
+
+        assertThatThrownBy(() -> helloCall.changeStatusToInProgress())
+                .isInstanceOf(InvalidStatusException.class)
+                .hasMessage("안부전화 서비스가 수행 대기중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + HelloCall.Status.IN_PROGRESS);
+
+        helloCall.changeStatusToPendingComplete();
+
+        assertThatThrownBy(() -> helloCall.changeStatusToWaiting())
+                .isInstanceOf(InvalidStatusException.class)
+                .hasMessage("안부전화 서비스가 수행중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + HelloCall.Status.PENDING_COMPLETE);
+    }
+
+    @Test
+    @DisplayName("Update HelloCall 테스트")
+    void updateHelloCallTest() {
+        helloCall.updateHelloCall(
+                LocalDate.of(2024, 10, 2),
+                LocalDate.of(2024, 10, 12),
+                12000,
+                45,
+                "Updated Requirement"
+        );
+
+        assertThat(helloCall.getStartDate()).isEqualTo(LocalDate.of(2024, 10, 2));
+        assertThat(helloCall.getEndDate()).isEqualTo(LocalDate.of(2024, 10, 12));
+        assertThat(helloCall.getPrice()).isEqualTo(12000);
+        assertThat(helloCall.getServiceTime()).isEqualTo(45);
+        assertThat(helloCall.getRequirement()).isEqualTo("Updated Requirement");
+    }
+
+    @Test
+    @DisplayName("Update HelloCall 예외 발생 테스트")
+    void updateHelloCallThrowsInvalidStatusException() {
+        helloCall.changeStatusToInProgress();
+
+        assertThatThrownBy(() -> helloCall.updateHelloCall(
+                LocalDate.of(2024, 10, 2),
+                LocalDate.of(2024, 10, 12),
+                12000,
+                45,
+                "Updated Requirement"
+        )).isInstanceOf(InvalidStatusException.class)
+                .hasMessage("안부전화 서비스가 수행 대기중일 때만 수정이 가능합니다.");
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/entity/HelloCallTimeLogTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/entity/HelloCallTimeLogTest.java
@@ -1,0 +1,57 @@
+package com.example.sinitto.hellocall.entity;
+
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.HelloCallTimeLog;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Sinitto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HelloCallTimeLogTest {
+
+    private HelloCall helloCall;
+    private Sinitto sinitto;
+    private HelloCallTimeLog helloCallTimeLog;
+
+    @BeforeEach
+    void setup() {
+        helloCall = new HelloCall(LocalDateTime.now().toLocalDate(), LocalDateTime.now().toLocalDate(), 10000, 30, "Test Requirement", null);
+        Member member = new Member("Sinitto Test", "01012345678", "sinitto@test.com", true);
+        sinitto = new Sinitto("테스트은행", "1111222233334444", member);
+
+        helloCallTimeLog = new HelloCallTimeLog(helloCall, sinitto);
+    }
+
+    @Test
+    @DisplayName("HelloCallTimeLog 생성자 테스트")
+    void constructorTest() {
+        assertThat(helloCallTimeLog).isNotNull();
+        assertThat(helloCallTimeLog.getHelloCall()).isEqualTo(helloCall);
+        assertThat(helloCallTimeLog.getSinitto()).isEqualTo(sinitto);
+    }
+
+    @Test
+    @DisplayName("시작 및 종료 시간 설정 테스트")
+    void setStartAndEndDateTimeTest() {
+        LocalDateTime startDateAndTime = LocalDateTime.now();
+        LocalDateTime endDateAndTime = startDateAndTime.plusHours(1);
+
+        helloCallTimeLog.setStartDateAndTime(startDateAndTime);
+        helloCallTimeLog.setEndDateAndTime(endDateAndTime);
+
+        assertThat(helloCallTimeLog.getStartDateAndTime()).isEqualTo(startDateAndTime);
+        assertThat(helloCallTimeLog.getEndDateAndTime()).isEqualTo(endDateAndTime);
+    }
+
+    @Test
+    @DisplayName("Sinitto 이름 가져오기 테스트")
+    void getSinittoNameTest() {
+        String expectedName = sinitto.getMember().getName();
+        assertThat(helloCallTimeLog.getSinittoName()).isEqualTo(expectedName);
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/entity/TimeSlotTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/entity/TimeSlotTest.java
@@ -1,0 +1,67 @@
+package com.example.sinitto.hellocall.entity;
+
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.TimeSlot;
+import com.example.sinitto.helloCall.exception.TimeRuleException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TimeSlotTest {
+
+    private HelloCall helloCall;
+    private TimeSlot timeSlot;
+
+    @BeforeEach
+    void setup() {
+        helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(1), 10000, 30, "Test Requirement", null);
+
+        timeSlot = new TimeSlot("Monday", LocalTime.of(9, 0), LocalTime.of(10, 0), helloCall);
+    }
+
+    @Test
+    @DisplayName("TimeSlot 생성자 테스트 - 유효한 입력")
+    void constructorTest_ValidInput() {
+        assertThat(timeSlot.getDayName()).isEqualTo("Monday");
+        assertThat(timeSlot.getStartTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(timeSlot.getEndTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(timeSlot.getHelloCall()).isEqualTo(helloCall);
+    }
+
+    @Test
+    @DisplayName("TimeSlot 생성자 테스트 - 잘못된 시간 순서")
+    void constructorTest_InvalidTimeOrder() {
+        assertThatThrownBy(() -> new TimeSlot("Monday", LocalTime.of(10, 0), LocalTime.of(9, 0), helloCall))
+                .isInstanceOf(TimeRuleException.class)
+                .hasMessage("시작시간이 종료시간 이후일 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("TimeSlot 시간 업데이트 테스트 - 유효한 시간")
+    void updateTimeSlot_ValidTime() {
+        LocalTime newStartTime = LocalTime.of(10, 0);
+        LocalTime newEndTime = LocalTime.of(11, 0);
+
+        timeSlot.updateTimeSlot(newStartTime, newEndTime);
+
+        assertThat(timeSlot.getStartTime()).isEqualTo(newStartTime);
+        assertThat(timeSlot.getEndTime()).isEqualTo(newEndTime);
+    }
+
+    @Test
+    @DisplayName("TimeSlot 시간 업데이트 테스트 - 잘못된 시간 순서")
+    void updateTimeSlot_InvalidTimeOrder() {
+        LocalTime newStartTime = LocalTime.of(11, 0);
+        LocalTime newEndTime = LocalTime.of(10, 0);
+
+        assertThatThrownBy(() -> timeSlot.updateTimeSlot(newStartTime, newEndTime))
+                .isInstanceOf(TimeRuleException.class)
+                .hasMessage("시작시간이 종료시간 이후일 수 없습니다.");
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/repository/HelloCallRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/HelloCallRepositoryTest.java
@@ -113,7 +113,7 @@ class HelloCallRepositoryTest {
                 "요구사항", senior);
         helloCallRepository.save(helloCall);
 
-        boolean exists = helloCallRepository.existsBySenior(senior);
+        boolean exists = helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING));
 
         assertThat(exists).isTrue();
     }
@@ -124,7 +124,7 @@ class HelloCallRepositoryTest {
         Senior notExistingSenior = new Senior("NonExistent", "01099999999", seniorMember);
         seniorRepository.save(notExistingSenior);
 
-        boolean exists = helloCallRepository.existsBySenior(notExistingSenior);
+        boolean exists = helloCallRepository.existsBySeniorAndStatusIn(notExistingSenior, List.of(HelloCall.Status.WAITING));
 
         assertThat(exists).isFalse();
     }

--- a/src/test/java/com/example/sinitto/hellocall/repository/HelloCallRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/HelloCallRepositoryTest.java
@@ -1,0 +1,153 @@
+package com.example.sinitto.hellocall.repository;
+
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.repository.HelloCallRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.entity.Sinitto;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.sinitto.repository.SinittoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class HelloCallRepositoryTest {
+
+    @Autowired
+    private HelloCallRepository helloCallRepository;
+
+    @Autowired
+    private SeniorRepository seniorRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SinittoRepository sinittoRepository;
+
+    private Member sinittoMember1;
+    private Member sinittoMember2;
+    private Member seniorMember;
+    private Sinitto sinitto1;
+    private Sinitto sinitto2;
+    private Senior senior;
+
+    @BeforeEach
+    void setUp() {
+        sinittoMember1 = new Member("test1", "01011111111", "test1@test.com", true);
+        memberRepository.save(sinittoMember1);
+
+        sinitto1 = new Sinitto("sinittoBank1", "BankAccount1", sinittoMember1);
+        sinittoRepository.save(sinitto1);
+
+        sinittoMember2 = new Member("test2", "01022222222", "test2@test.com", true);
+        memberRepository.save(sinittoMember2);
+
+        sinitto2 = new Sinitto("SinittoBank2", "BankAccount2", sinittoMember2);
+        sinittoRepository.save(sinitto2);
+
+        seniorMember = new Member("test3", "01033333333", "test3@test.com", false);
+        memberRepository.save(seniorMember);
+
+        senior = new Senior("SeniorName", "01044444444", seniorMember);
+        seniorRepository.save(senior);
+    }
+
+    @Test
+    @DisplayName("Senior 기반으로 HelloCall 찾기 테스트")
+    void findBySeniorTest() {
+        HelloCall helloCall = new HelloCall(LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 2), 10000, 60,
+                "요구사항", senior);
+        helloCallRepository.save(helloCall);
+
+        Optional<HelloCall> foundHelloCall = helloCallRepository.findBySenior(senior);
+
+        assertThat(foundHelloCall).isPresent();
+        assertThat(foundHelloCall.get().getSenior()).isEqualTo(senior);
+    }
+
+    @Test
+    @DisplayName("Sinitto 기반으로 HelloCall 리스트 찾기 테스트")
+    void findAllBySinittoTest() {
+        Senior senior1 = new Senior("Senior1", "01012345678", sinittoMember2);
+        seniorRepository.save(senior1);
+        Senior senior2 = new Senior("Senior2", "01098765432", sinittoMember2);
+        seniorRepository.save(senior2);
+
+        HelloCall helloCall1 = new HelloCall(LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 2), 10000, 60,
+                "요구사항1", senior1);
+        HelloCall helloCall2 = new HelloCall(LocalDate.of(2024, 1, 3),
+                LocalDate.of(2024, 1, 4), 15000, 90,
+                "요구사항2", senior2);
+
+        helloCall1.setSinitto(sinitto1);
+        helloCall2.setSinitto(sinitto1);
+
+        helloCallRepository.save(helloCall1);
+        helloCallRepository.save(helloCall2);
+
+        List<HelloCall> helloCalls = helloCallRepository.findAllBySinitto(sinitto1);
+
+        assertThat(helloCalls).hasSize(2);
+        assertThat(helloCalls.get(0).getSinitto()).isEqualTo(sinitto1);
+        assertThat(helloCalls.get(1).getSinitto()).isEqualTo(sinitto1);
+    }
+
+    @Test
+    @DisplayName("Senior 존재 여부 테스트")
+    void existsBySeniorTest() {
+        HelloCall helloCall = new HelloCall(LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 2), 10000, 60,
+                "요구사항", senior);
+        helloCallRepository.save(helloCall);
+
+        boolean exists = helloCallRepository.existsBySenior(senior);
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("Senior가 안부전화에 할당되지 않았을 경우 테스트")
+    void doesNotExistBySeniorTest() {
+        Senior notExistingSenior = new Senior("NonExistent", "01099999999", seniorMember);
+        seniorRepository.save(notExistingSenior);
+
+        boolean exists = helloCallRepository.existsBySenior(notExistingSenior);
+
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("안부전화 담당 Sinitto가 변경되었을 경우, 변경이 잘 적용되는지 테스트")
+    void testChangeSinittoInHelloCall() {
+        HelloCall helloCall = new HelloCall(LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 2), 10000, 60,
+                "요구사항", senior);
+
+        helloCall.setSinitto(sinitto1);
+        helloCallRepository.save(helloCall);
+
+        Optional<HelloCall> savedHelloCall = helloCallRepository.findById(helloCall.getId());
+        assertThat(savedHelloCall).isPresent();
+        assertThat(savedHelloCall.get().getSinitto()).isEqualTo(sinitto1);
+
+        savedHelloCall.get().setSinitto(sinitto2);
+        helloCallRepository.save(savedHelloCall.get());
+
+        Optional<HelloCall> updatedHelloCall = helloCallRepository.findById(helloCall.getId());
+        assertThat(updatedHelloCall).isPresent();
+        assertThat(updatedHelloCall.get().getSinitto()).isEqualTo(sinitto2);
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/repository/HelloCallRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/HelloCallRepositoryTest.java
@@ -150,4 +150,29 @@ class HelloCallRepositoryTest {
         assertThat(updatedHelloCall).isPresent();
         assertThat(updatedHelloCall.get().getSinitto()).isEqualTo(sinitto2);
     }
+
+    @Test
+    @DisplayName("Senior 리스트 기반으로 HelloCall 찾기 테스트")
+    void findAllBySeniorInTest() {
+        Senior senior1 = new Senior("Senior1", "01055555555", seniorMember);
+        Senior senior2 = new Senior("Senior2", "01066666666", seniorMember);
+        seniorRepository.save(senior1);
+        seniorRepository.save(senior2);
+
+        HelloCall helloCall1 = new HelloCall(LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 2), 10000, 60,
+                "요구사항1", senior1);
+        HelloCall helloCall2 = new HelloCall(LocalDate.of(2024, 1, 3),
+                LocalDate.of(2024, 1, 4), 15000, 90,
+                "요구사항2", senior2);
+
+        helloCallRepository.save(helloCall1);
+        helloCallRepository.save(helloCall2);
+
+        List<HelloCall> helloCalls = helloCallRepository.findAllBySeniorIn(List.of(senior1, senior2));
+
+        assertThat(helloCalls).hasSize(2);
+        assertThat(helloCalls.get(0).getSenior()).isEqualTo(senior1);
+        assertThat(helloCalls.get(1).getSenior()).isEqualTo(senior2);
+    }
 }

--- a/src/test/java/com/example/sinitto/hellocall/repository/HelloCallTimeLogRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/HelloCallTimeLogRepositoryTest.java
@@ -97,4 +97,23 @@ class HelloCallTimeLogRepositoryTest {
         assertThat(timeLogs.get(0).getStartDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 10, 0));
         assertThat(timeLogs.get(1).getStartDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 12, 0));
     }
+
+    @Test
+    @DisplayName("Sinitto와 HelloCall 기반으로 가장 최근의 HelloCallTimeLog 찾기 테스트")
+    void findTopBySinittoAndHelloCallOrderByStartDateAndTimeDescTest() {
+        HelloCallTimeLog timeLog1 = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.of(2024, 1, 1, 10, 0), LocalDateTime.of(2024, 1, 1, 11, 0));
+        HelloCallTimeLog timeLog2 = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.of(2024, 1, 1, 12, 0), LocalDateTime.of(2024, 1, 1, 13, 0));
+
+        helloCallTimeLogRepository.save(timeLog1);
+        helloCallTimeLogRepository.save(timeLog2);
+
+        Optional<HelloCallTimeLog> recentTimeLog = helloCallTimeLogRepository
+                .findTopBySinittoAndHelloCallOrderByStartDateAndTimeDesc(sinitto, helloCall);
+
+        assertThat(recentTimeLog).isPresent();
+        assertThat(recentTimeLog.get().getHelloCall()).isEqualTo(helloCall);
+        assertThat(recentTimeLog.get().getSinitto()).isEqualTo(sinitto);
+        assertThat(recentTimeLog.get().getStartDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 12, 0));
+        assertThat(recentTimeLog.get().getEndDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 13, 0));
+    }
 }

--- a/src/test/java/com/example/sinitto/hellocall/repository/HelloCallTimeLogRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/HelloCallTimeLogRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.example.sinitto.hellocall.repository;
+
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.HelloCallTimeLog;
+import com.example.sinitto.helloCall.repository.HelloCallRepository;
+import com.example.sinitto.helloCall.repository.HelloCallTimeLogRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.entity.Sinitto;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.sinitto.repository.SinittoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class HelloCallTimeLogRepositoryTest {
+
+    @Autowired
+    private HelloCallTimeLogRepository helloCallTimeLogRepository;
+
+    @Autowired
+    private HelloCallRepository helloCallRepository;
+
+    @Autowired
+    private SinittoRepository sinittoRepository;
+
+    @Autowired
+    private SeniorRepository seniorRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member sinittoMember;
+    private Member seniorMember;
+    private Sinitto sinitto;
+    private Senior senior;
+    private HelloCall helloCall;
+
+    @BeforeEach
+    void setUp() {
+        sinittoMember = new Member("testSinitto", "01011112222", "sinitto@test.com", true);
+        memberRepository.save(sinittoMember);
+
+        sinitto = new Sinitto("sinittoBank", "sinittoAccount", sinittoMember);
+        sinittoRepository.save(sinitto);
+
+        seniorMember = new Member("testSenior", "01033334444", "senior@test.com", false);
+        memberRepository.save(seniorMember);
+
+        senior = new Senior("SeniorName", "01055556666", seniorMember);
+        seniorRepository.save(senior);
+
+        helloCall = new HelloCall(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 2), 10000, 60, "Test requirements", senior);
+        helloCallRepository.save(helloCall);
+    }
+
+    @Test
+    @DisplayName("로그 저장 및 Sinitto와 HelloCall ID 기반으로 특정 HelloCallTimeLog 찾기 테스트")
+    void findBySinittoAndHelloCallIdTest() {
+        HelloCallTimeLog timeLog = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.of(2024, 1, 1, 10, 0), LocalDateTime.of(2024, 1, 1, 11, 0));
+        helloCallTimeLogRepository.save(timeLog);
+
+        Optional<HelloCallTimeLog> foundTimeLog = helloCallTimeLogRepository.findBySinittoAndAndHelloCallId(sinitto, helloCall.getId());
+
+        assertThat(foundTimeLog).isPresent();
+        assertThat(foundTimeLog.get().getHelloCall()).isEqualTo(helloCall);
+        assertThat(foundTimeLog.get().getSinitto()).isEqualTo(sinitto);
+        assertThat(foundTimeLog.get().getStartDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 10, 0));
+        assertThat(foundTimeLog.get().getEndDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 11, 0));
+    }
+
+    @Test
+    @DisplayName("HelloCall ID 기반으로 모든 HelloCallTimeLog 리스트 찾기 테스트")
+    void findAllByHelloCallIdTest() {
+        HelloCallTimeLog timeLog1 = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.of(2024, 1, 1, 10, 0), LocalDateTime.of(2024, 1, 1, 11, 0));
+        HelloCallTimeLog timeLog2 = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.of(2024, 1, 1, 12, 0), LocalDateTime.of(2024, 1, 1, 13, 0));
+
+        helloCallTimeLogRepository.save(timeLog1);
+        helloCallTimeLogRepository.save(timeLog2);
+
+        List<HelloCallTimeLog> timeLogs = helloCallTimeLogRepository.findAllByHelloCallId(helloCall.getId());
+
+        assertThat(timeLogs).hasSize(2);
+        assertThat(timeLogs.get(0).getHelloCall()).isEqualTo(helloCall);
+        assertThat(timeLogs.get(1).getHelloCall()).isEqualTo(helloCall);
+        assertThat(timeLogs.get(0).getStartDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 10, 0));
+        assertThat(timeLogs.get(1).getStartDateAndTime()).isEqualTo(LocalDateTime.of(2024, 1, 1, 12, 0));
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/repository/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/TimeSlotRepositoryTest.java
@@ -71,4 +71,19 @@ class TimeSlotRepositoryTest {
 
         assertThat(foundTimeSlot).isNotPresent();
     }
+
+    @Test
+    @DisplayName("HelloCall 기반으로 모든 TimeSlot 삭제 테스트")
+    void deleteAllByHelloCallTest() {
+        TimeSlot timeSlot1 = new TimeSlot("월", LocalTime.of(9, 0), LocalTime.of(10, 0), helloCall);
+        TimeSlot timeSlot2 = new TimeSlot("화", LocalTime.of(10, 0), LocalTime.of(11, 0), helloCall);
+        timeSlotRepository.save(timeSlot1);
+        timeSlotRepository.save(timeSlot2);
+
+        assertThat(timeSlotRepository.findAllByHelloCall(helloCall)).hasSize(2);
+
+        timeSlotRepository.deleteAllByHelloCall(helloCall);
+
+        assertThat(timeSlotRepository.findAllByHelloCall(helloCall)).isEmpty();
+    }
 }

--- a/src/test/java/com/example/sinitto/hellocall/repository/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/TimeSlotRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.example.sinitto.hellocall.repository;
+
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.TimeSlot;
+import com.example.sinitto.helloCall.repository.HelloCallRepository;
+import com.example.sinitto.helloCall.repository.TimeSlotRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TimeSlotRepositoryTest {
+
+    @Autowired
+    private TimeSlotRepository timeSlotRepository;
+
+    @Autowired
+    private HelloCallRepository helloCallRepository;
+
+    @Autowired
+    private SeniorRepository seniorRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private HelloCall helloCall;
+    private Senior senior;
+    private Member seniorMember;
+
+    @BeforeEach
+    void setUp() {
+        seniorMember = new Member("testSenior", "01033334444", "senior@test.com", false);
+        memberRepository.save(seniorMember);
+
+        senior = new Senior("SeniorName", "01055556666", seniorMember);
+        seniorRepository.save(senior);
+
+        helloCall = new HelloCall(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 2), 10000, 60, "테스트 요구사항", senior);
+        helloCallRepository.save(helloCall);
+    }
+
+    @Test
+    @DisplayName("HelloCall 및 DayName을 기반으로 TimeSlot 찾기 테스트")
+    void findByHelloCallAndDayTest() {
+        TimeSlot timeSlot = new TimeSlot("금", LocalTime.of(10, 0), LocalTime.of(11, 0), helloCall);
+        timeSlotRepository.save(timeSlot);
+
+        Optional<TimeSlot> foundTimeSlot = timeSlotRepository.findByHelloCallAndDayName(helloCall, "금");
+
+        assertThat(foundTimeSlot).isPresent();
+        assertThat(foundTimeSlot.get().getHelloCall()).isEqualTo(helloCall);
+        assertThat(foundTimeSlot.get().getDayName()).isEqualTo("금");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 DayName으로 TimeSlot 찾기 테스트")
+    void findByHelloCallAndNonExistentDayTest() {
+        Optional<TimeSlot> foundTimeSlot = timeSlotRepository.findByHelloCallAndDayName(helloCall, "월");
+
+        assertThat(foundTimeSlot).isNotPresent();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #47 

## 📝 작업 내용
- HelloCall과 TimeSlot 엔티티 생성 및 관계성 정의
- 보호자용 안부전화 비즈니스 로직 구현
- 시니또용 안부전화 비즈니스 로직 구현
- 보호자의 확인을 위한 시니또의 안부전화 타임로그 기록 로직 구현 및 HelloCallTimeLog 엔티티 생성, 관계성 정의
- 안부전화 가격 산출용 비즈니스 로직 구현
- LocalTime 직렬화 처리
- 최종 컨트롤러 구현
- 단위 테스트 및 repo 테스트 코드 작성
- swagger를 통한 e2e 테스트 수행


## 💬 리뷰 요구사항(선택)
- 도훈님께서 작성하신 senior 엔티티에서 기본생성자가 없어 오류가 발생한적이 있어 protected 타입의 기본생성자를 추가하였습니다..! 도훈님께서 충돌 확인해주시면 감사드리겠습니다.
- ui에 나오지 않은 부분들은 임의로 로직을 가정하고 구현하였습니다. 프로토타입이라고 생각하고 확인해주시면 좋을 것 같습니다!
- 현재 시니또 repo에 등록을 위해서는 반드시 계좌 정보를 등록해야 하는데, 회원가입 후 계좌 정보를 등록을 강제하는 등의 로직이 있으면 좋을 것 같습니다.
- 안부전화 정보 수정같은 경우, TimeSlot 리스트 내 객체들을 줄이거나 추가해도 확인 후 자동 적용되도록 구현했습니다.
- HelloCallService 내용이 많아서 그런가 hide상태로 아래와 같이 나오는데, 핵심 비즈니스 로직이라 확인 후 코멘트 부탁드립니다..!
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/9b0615dd-7c97-486f-9494-886173876067">


- **request 관련 주의사항 1** : dayName 필드의 경우 String 타입의 {"월", "화", "수", "목", "금", "토", "일"} 만 입력 가능합니다. (안부전화 서비스비용 계산 로직 적용 및 프론트 미변형 사용을 위해)
- **request 관련 주의사항 2** : LocalTime의 경우 Swagger 기본 타입이 
```
  "startTime": {
        "hour": 0,
        "minute": 0,
        "second": 0,
        "nano": 0
      }
```
이와 같이 나오는데, 관련 dto에서 직렬화 처리를 해두어서
```
"startTime": "00:00"
```
위와 같이 입력하면 됩니다

### 보호자의 로직
안부전화 서비스 생성, 안부전화 서비스 비용 조회, 본인이 신청한 안부전화 리스트 조회, 안부전화 수정 및 삭제(상태가 대기중일때만 가능), 안부전화 정보 상세보기, 시니또의 안부전화 시작 및 종료시간 로그 리스트 조회, 시니또가 안부전화 서비스를 완료한 후 작성한 보고서 조회, 완료 대기상태의 안부전화 상태 완료로 변경
### 시니또의 로직
수락을 원하는(상태가 대기중) 전체 안부전화 리스트 조회, 안부전화 서비스 수락, 진행중인 안부전화 서비스 취소, 본인이 수락한 안부전화 리스트 조회, 안부전화 정보 상세보기,  안부전화 서비스 시작시간 기록 버튼, 안부전화 서비스 종료시간 기록 버튼, 소통 보고서 작성 및 완료 대기 상태로 변경


### API 경로 및 종류
![image](https://github.com/user-attachments/assets/34019233-cf58-4505-8dac-48f7a190ffad)

### Swagger를 통한 테스트 결과
#### 보호자가 안부전화 가격을 조회 (24.10.08 ~ 24.10.20 기간 동안 수요일, 금요일 18:00~20:00에 10분씩 서비스 요청시)
![image](https://github.com/user-attachments/assets/ddf28391-33da-4de9-a47a-13f4983ad4f6)
#### 보호자가 가격을 확인하고 안부전화 서비스를 신청 (요구 사항 포함)
![image](https://github.com/user-attachments/assets/422781b9-dd28-4d3d-b243-38dd29091e3d)
#### 시니또가 로그인한 후 안부전화 서비스 전체 리스트 확인 (페이징처리됨)
![image](https://github.com/user-attachments/assets/912a27ae-dd09-4d7b-84a7-730dd244f8e5)
#### 시니또가 안부전화 정보 상세보기
![image](https://github.com/user-attachments/assets/cb2bbd17-3b03-4f38-b33a-d3f5b6c179d9)
#### 시니또가 안부전화 서비스를 수락
![image](https://github.com/user-attachments/assets/cef76813-7cd7-4586-8abf-0d2181ad1831)
#### 시니또가 이후에 접속했을 경우에도 확인할 수 있게 본인에게 할당된 안부전화 리스트 조회, 상태 확인 가능(현재는 할당된게 한개라 한개만 뜸) 
![image](https://github.com/user-attachments/assets/63d6df5d-8220-4559-973b-5c3138d3c106)
#### 시니또가 안부전화를 시작할 때 버튼 등을 눌러 시작 시간을 기록
![image](https://github.com/user-attachments/assets/2a653e14-d867-474f-9cb4-74d831b0b44a)
#### 시니또가 안부전화를 끝내면 버튼 등을 눌러 종료 시간을 기록
![image](https://github.com/user-attachments/assets/ff4c8cf4-3283-4f55-999b-3a2e7882a742)
#### 만약 시니또가 안부전화 기간이 끝나기 전에 종료 및 리포트를 내려고 시도할 경우
![image](https://github.com/user-attachments/assets/c20aacf8-5537-4d26-a94a-e07104c91a79)
#### 보호자가 수시로 시니또가 안부전화를 잘 했는지 확인하기 위한 타임로그 조회
![image](https://github.com/user-attachments/assets/eb78d940-0e49-441b-9135-2279349ba953)
#### 시니또가 안부전화 서비스 기간을 마쳐, 최종 완료 후 리포트를 작성 (종료 시간이 오늘인걸로 안부전화를 새로 하나 더 만들었습니다)
![image](https://github.com/user-attachments/assets/45051df4-da31-4066-a1f1-0fad348f8bff)
#### 시니또가 다시 본인에게 할당된 안부전화 리스트를 조회 (이제 2개가 되었습니다. 하나는 진행중, 하나는 완료 대기상태)
![image](https://github.com/user-attachments/assets/c0937bde-39dd-4a58-9fc8-d654f99fc805)
#### 보호자가 소통 보고서를 조회
![image](https://github.com/user-attachments/assets/956f6d82-b1e0-42dd-b6cd-b07976d3c4c6)
#### 보호자가 해당 안부전화를 완료처리 (이 때 포인트가 지급됩니다.)
[사진x]
#### 시니또가 다시 본인에게 할당된 안부전화 확인 (완료대기였던게 완료로 바뀜)
![image](https://github.com/user-attachments/assets/57264d2f-3bf3-4971-a1cf-6bac8633cb05)

## ⏰ 현재 버그
테스트코드 및 swagger를 통한 테스트 결과 문제 없습니다.

## ✏ Git Close
close #47 