### PR TITLE
Refactor: 2차 멘토링 코멘트 반영

### DIFF
--- a/src/main/java/com/example/sinitto/auth/controller/AuthControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/auth/controller/AuthControllerAdvice.java
@@ -15,11 +15,16 @@ import java.net.URI;
 @RestControllerAdvice(basePackages = "com.example.sinitto.auth")
 public class AuthControllerAdvice {
 
+    private static final String UNAUTHORIZED_ACCESS_URI = "/errors/unauthorized-access";
+    private static final String JWT_EXPIRATION_URI = "/errors/unauthorized-access-by-jwt-expiration";
+    private static final String TOKEN_NOT_FOUND_URI = "/errors/token-not-found";
+    private static final String KAKAO_REFRESH_TOKEN_EXPIRATION_URI = "/errors/unauthorized-access-by-kakao-refresh-token-expiration";
+
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ProblemDetail> handleUnauthorizedException(UnauthorizedException ex) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED,
                 ex.getMessage());
-        problemDetail.setType(URI.create("/errors/unauthorized-access"));
+        problemDetail.setType(URI.create(UNAUTHORIZED_ACCESS_URI));
         problemDetail.setTitle("Unauthorized Access");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
     }
@@ -28,7 +33,7 @@ public class AuthControllerAdvice {
     public ResponseEntity<ProblemDetail> handleJWTExpirationException(JWTExpirationException ex) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED,
                 ex.getMessage());
-        problemDetail.setType(URI.create("/errors/unauthorized-access-by-jwt-expiration"));
+        problemDetail.setType(URI.create(JWT_EXPIRATION_URI));
         problemDetail.setTitle("Unauthorized Access By JWT Expiration");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
     }
@@ -37,7 +42,7 @@ public class AuthControllerAdvice {
     public ResponseEntity<ProblemDetail> handleTokenNotFoundException(TokenNotFoundException ex) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND,
                 ex.getMessage());
-        problemDetail.setType(URI.create("/errors/token-not-found"));
+        problemDetail.setType(URI.create(TOKEN_NOT_FOUND_URI));
         problemDetail.setTitle("Token Not Found");
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
@@ -46,7 +51,7 @@ public class AuthControllerAdvice {
     public ResponseEntity<ProblemDetail> handleKakaoRefreshTokenExpirationException(KakaoRefreshTokenExpirationException ex) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED,
                 ex.getMessage());
-        problemDetail.setType(URI.create("/errors/unauthorized-access-by-kakao-refresh-token-expiration"));
+        problemDetail.setType(URI.create(KAKAO_REFRESH_TOKEN_EXPIRATION_URI));
         problemDetail.setTitle("Unauthorized Access By Kakao Refresh Token Expiration");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
     }

--- a/src/main/java/com/example/sinitto/auth/controller/AuthControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/auth/controller/AuthControllerAdvice.java
@@ -1,9 +1,6 @@
 package com.example.sinitto.auth.controller;
 
-import com.example.sinitto.auth.exception.JWTExpirationException;
-import com.example.sinitto.auth.exception.KakaoRefreshTokenExpirationException;
-import com.example.sinitto.auth.exception.TokenNotFoundException;
-import com.example.sinitto.auth.exception.UnauthorizedException;
+import com.example.sinitto.auth.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +16,7 @@ public class AuthControllerAdvice {
     private static final String JWT_EXPIRATION_URI = "/errors/unauthorized-access-by-jwt-expiration";
     private static final String TOKEN_NOT_FOUND_URI = "/errors/token-not-found";
     private static final String KAKAO_REFRESH_TOKEN_EXPIRATION_URI = "/errors/unauthorized-access-by-kakao-refresh-token-expiration";
+    private static final String KAKAO_EMAIL_NOT_FOUND_URI = "/errors/kakao-email-not-found";
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ProblemDetail> handleUnauthorizedException(UnauthorizedException ex) {
@@ -54,5 +52,14 @@ public class AuthControllerAdvice {
         problemDetail.setType(URI.create(KAKAO_REFRESH_TOKEN_EXPIRATION_URI));
         problemDetail.setTitle("Unauthorized Access By Kakao Refresh Token Expiration");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
+    }
+
+    @ExceptionHandler(KakaoEmailNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleKakaoEmailNotFoundException(KakaoEmailNotFoundException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND,
+                ex.getMessage());
+        problemDetail.setType(URI.create(KAKAO_EMAIL_NOT_FOUND_URI));
+        problemDetail.setTitle("Kakao Email Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
 }

--- a/src/main/java/com/example/sinitto/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/example/sinitto/auth/dto/KakaoTokenResponse.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 public record KakaoTokenResponse(
         String accessToken,
         String refreshToken,
-        Integer expiresIn,
-        Integer refreshTokenExpiresIn
+        int expiresIn,
+        int refreshTokenExpiresIn
 
 ) {
 

--- a/src/main/java/com/example/sinitto/auth/entity/KakaoToken.java
+++ b/src/main/java/com/example/sinitto/auth/entity/KakaoToken.java
@@ -24,28 +24,28 @@ public class KakaoToken {
     @NotNull
     private String refreshToken;
     @NotNull
-    private int expires_in;
+    private int expiresIn;
     @NotNull
-    private int refresh_token_expires_in;
+    private int refreshTokenExpiresIn;
 
     public KakaoToken(String memberEmail, String accessToken, String refreshToken,
-                      int expires_in, int refresh_token_expires_in) {
+                      int expiresIn, int refreshTokenExpiresIn) {
         this.memberEmail = memberEmail;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.expires_in = expires_in;
-        this.refresh_token_expires_in = refresh_token_expires_in;
+        this.expiresIn = expiresIn;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
     }
 
     protected KakaoToken() {
     }
 
     public boolean isAccessTokenExpired() {
-        return LocalDateTime.now().isAfter(issuedAt.plusSeconds(expires_in));
+        return LocalDateTime.now().isAfter(issuedAt.plusSeconds(expiresIn));
     }
 
     public boolean isRefreshTokenExpired() {
-        return LocalDateTime.now().isAfter(issuedAt.plusSeconds(refresh_token_expires_in));
+        return LocalDateTime.now().isAfter(issuedAt.plusSeconds(refreshTokenExpiresIn));
     }
 
     public String getAccessToken() {
@@ -65,11 +65,11 @@ public class KakaoToken {
     }
 
     public void updateKakaoToken(String accessToken, String refreshToken,
-                                 int expires_in, int refresh_token_expires_in) {
+                                 int expiresIn, int refreshTokenExpiresIn) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.expires_in = expires_in;
-        this.refresh_token_expires_in = refresh_token_expires_in;
+        this.expiresIn = expiresIn;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
         this.issuedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/sinitto/auth/exception/KakaoEmailNotFoundException.java
+++ b/src/main/java/com/example/sinitto/auth/exception/KakaoEmailNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.auth.exception;
+
+public class KakaoEmailNotFoundException extends RuntimeException {
+    public KakaoEmailNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
@@ -14,6 +14,8 @@ import java.net.URI;
 @Service
 public class KakaoApiService {
 
+    private static final String KAKAO_AUTH_BASE_URL = "https://kauth.kakao.com/oauth";
+    private static final String KAKAO_API_BASE_URL = "https://kapi.kakao.com/v2/user";
     private final RestTemplate restTemplate;
     private final KakaoProperties kakaoProperties;
 
@@ -23,14 +25,15 @@ public class KakaoApiService {
     }
 
     public String getAuthorizationUrl() {
-        return "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="
+        return KAKAO_AUTH_BASE_URL + "/authorize?response_type=code&client_id="
                 + kakaoProperties.clientId() + "&redirect_uri=" + kakaoProperties.redirectUri();
     }
 
     public KakaoTokenResponse getAccessToken(String authorizationCode) {
-        String url = "https://kauth.kakao.com/oauth/token";
+        String url = KAKAO_AUTH_BASE_URL + "/token";
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+
         LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", kakaoProperties.clientId());
@@ -47,8 +50,7 @@ public class KakaoApiService {
     }
 
     public KakaoTokenResponse refreshAccessToken(String refreshToken) {
-        String url = "https://kauth.kakao.com/oauth/token";
-
+        String url = KAKAO_AUTH_BASE_URL + "/token";
         String body = "grant_type=refresh_token&client_id=" + kakaoProperties.clientId()
                 + "&refresh_token=" + refreshToken;
 
@@ -64,7 +66,7 @@ public class KakaoApiService {
     }
 
     public KakaoUserResponse getUserInfo(String accessToken) {
-        String url = "https://kapi.kakao.com/v2/user/me";
+        String url = KAKAO_API_BASE_URL + "/me";
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setBearerAuth(accessToken);
@@ -79,5 +81,4 @@ public class KakaoApiService {
 
         return response.getBody();
     }
-
 }

--- a/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
@@ -80,7 +80,7 @@ public class KakaoApiService {
         ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
                 url, HttpMethod.POST, request, KakaoUserResponse.class);
 
-        if (response.getBody().kakaoAccount().email().isEmpty()) {
+        if (response.getBody().kakaoAccount().email() == null) {
             throw new KakaoEmailNotFoundException("카카오 계정으로부터 전달받은 이메일이 없습니다.");
         }
 

--- a/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
@@ -2,6 +2,7 @@ package com.example.sinitto.auth.service;
 
 import com.example.sinitto.auth.dto.KakaoTokenResponse;
 import com.example.sinitto.auth.dto.KakaoUserResponse;
+import com.example.sinitto.auth.exception.KakaoEmailNotFoundException;
 import com.example.sinitto.common.properties.KakaoProperties;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -78,6 +79,10 @@ public class KakaoApiService {
 
         ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
                 url, HttpMethod.POST, request, KakaoUserResponse.class);
+
+        if (response.getBody().kakaoAccount().email().isEmpty()) {
+            throw new KakaoEmailNotFoundException("카카오 계정으로부터 전달받은 이메일이 없습니다.");
+        }
 
         return response.getBody();
     }

--- a/src/main/java/com/example/sinitto/common/config/RestTemplateResponseErrorHandler.java
+++ b/src/main/java/com/example/sinitto/common/config/RestTemplateResponseErrorHandler.java
@@ -1,0 +1,42 @@
+package com.example.sinitto.common.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+
+@Component
+public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            RestTemplateResponseErrorHandler.class);
+
+    @Override
+    public boolean hasError(ClientHttpResponse httpResponse) throws IOException {
+        var statusCode = httpResponse.getStatusCode();
+        return statusCode.is4xxClientError() || statusCode.is5xxServerError();
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse httpResponse) throws IOException {
+        var statusCode = httpResponse.getStatusCode();
+        String responseBody = new String(httpResponse.getBody().readAllBytes());
+
+        if (statusCode.is4xxClientError()) {
+            LOGGER.error("클라이언트 에러: {} - Response body: {}", statusCode, responseBody);
+            throw new HttpClientErrorException(statusCode, httpResponse.getStatusText(),
+                    httpResponse.getHeaders(), responseBody.getBytes(), null);
+        }
+
+        if (statusCode.is5xxServerError()) {
+            LOGGER.error("서버 에러: {} - Response body: {}", statusCode, responseBody);
+            throw new HttpServerErrorException(statusCode, httpResponse.getStatusText(),
+                    httpResponse.getHeaders(), responseBody.getBytes(), null);
+        }
+    }
+}

--- a/src/main/java/com/example/sinitto/common/config/WebConfig.java
+++ b/src/main/java/com/example/sinitto/common/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.common.config;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -8,12 +9,20 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.time.Duration;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private static final int TIME_OUT_DURATION = 5;
+
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, RestTemplateResponseErrorHandler errorHandler) {
+        return builder
+                .errorHandler(errorHandler)
+                .setConnectTimeout(Duration.ofSeconds(TIME_OUT_DURATION))
+                .setReadTimeout(Duration.ofSeconds(TIME_OUT_DURATION))
+                .build();
     }
 
     @Bean

--- a/src/main/java/com/example/sinitto/member/controller/MemberController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.member.controller;
 
-import com.example.sinitto.auth.dto.RegisterResponse;
+import com.example.sinitto.member.dto.RegisterResponse;
+import com.example.sinitto.common.annotation.MemberId;
 import com.example.sinitto.member.dto.SignupRequest;
 import com.example.sinitto.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
@@ -38,5 +36,12 @@ public class MemberController {
         RegisterResponse registerResponse = memberService.registerNewMember(request.name(), request.phoneNumber(),
                 request.email(), request.isSinitto());
         return ResponseEntity.status(HttpStatus.CREATED).body(registerResponse);
+    }
+
+    @Operation(summary = "멤버 로그아웃", description = "레디스에 저장되어있는 멤버의 refreshToken을 삭제합니다.")
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> memberLogout(@MemberId Long memberId) {
+        memberService.memberLogout(memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sinitto/member/dto/RegisterResponse.java
+++ b/src/main/java/com/example/sinitto/member/dto/RegisterResponse.java
@@ -1,4 +1,4 @@
-package com.example.sinitto.auth.dto;
+package com.example.sinitto.member.dto;
 
 public record RegisterResponse(
         String accessToken,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #51 

## 📝 작업 내용
- URI 경로 상수화
- 카카오 API 반환값 타입 변경
- 카멜케이스 통일화
- 카카오 Oauth BaseURL추가 및 상수화
- 카카오 API 에러 처리를 위한 RestTemplateResponseErrorHandler 추가
- 카카오 API 에러 로그 저장 로직 구현
- 카카오 ConnectTimeout 및 ReadTimeout 5초로 설정
- 로그아웃 (레디스에 저장된 리프레쉬 토큰 삭제)

## 💬 리뷰 요구사항(선택)
- 카카오API 에러 처리를 위해 RestTemplateResponseErrorHandler를 만들어 서버 응답 오류와 클라이언트 응답 오류에 대한 에러처리를 구현하였습니다.
- 유효성 검사는 필요한 필드가 email이기 때문에 email이 null값인지 확인하는 로직을 추가했습니다.
- 로그아웃 시 서버에서는 레디스에 저장된 해당 유저의 리프레쉬 토큰을 지워줍니다.

혹시 추가할 사항이나 개선점이 있다면 코멘트 부탁드립니다 :)

## ⏰ 현재 버그
리팩터링 후 코드 전체 테스트코드 구동 결과 이상 없습니다.

## ✏ Git Close
close #51 