### PR TITLE
Feat: 포인트 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation group: 'com.twilio.sdk', name: 'twilio', version: '10.5.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -192,9 +192,6 @@ public class HelloCallService {
             throw new UnauthorizedException("안부전화 신청을 취소할 권한이 없습니다.");
         }
 
-        helloCall.checkStatusIsWaiting();
-        helloCallRepository.delete(helloCall);
-
         Point point = pointRepository.findByMemberIdWithWriteLock(memberId)
                 .orElseThrow(() -> new PointNotFoundException("멤버에 연관된 포인트가 없습니다."));
 
@@ -207,6 +204,9 @@ public class HelloCallService {
                         helloCall.getPrice(),
                         PointLog.Status.SPEND_CANCEL)
         );
+
+        helloCall.checkStatusIsWaiting();
+        helloCallRepository.delete(helloCall);
     }
 
     @Transactional(readOnly = true)
@@ -266,7 +266,9 @@ public class HelloCallService {
 
         Point sinittoPoint = pointRepository.findByMember(helloCall.getSinitto().getMember())
                 .orElseThrow(() -> new PointNotFoundException("포인트 적립 받을 시니또와 연관된 포인트가 없습니다"));
+
         sinittoPoint.earn(helloCall.getPrice());
+
         pointLogRepository.save(
                 new PointLog(
                         PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN.getMessage(),
@@ -275,7 +277,6 @@ public class HelloCallService {
                         PointLog.Status.EARN)
         );
     }
-
 
     @Transactional(readOnly = true)
     public List<HelloCallReportResponse> readAllHelloCallReportByAdmin() {

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -19,6 +19,11 @@ import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.entity.Sinitto;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.entity.PointLog;
+import com.example.sinitto.point.exception.PointNotFoundException;
+import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
 import com.example.sinitto.sinitto.exception.SinittoNotFoundException;
 import com.example.sinitto.sinitto.repository.SinittoRepository;
 import org.springframework.data.domain.Page;
@@ -41,17 +46,21 @@ public class HelloCallService {
     private final MemberRepository memberRepository;
     private final SinittoRepository sinittoRepository;
     private final HelloCallTimeLogRepository helloCallTimeLogRepository;
+    private final PointRepository pointRepository;
+    private final PointLogRepository pointLogRepository;
 
 
     public HelloCallService(HelloCallRepository helloCallRepository, TimeSlotRepository timeSlotRepository,
                             SeniorRepository seniorRepository, MemberRepository memberRepository, SinittoRepository sinittoRepository,
-                            HelloCallTimeLogRepository helloCallTimeLogRepository) {
+                            HelloCallTimeLogRepository helloCallTimeLogRepository, PointRepository pointRepository, PointLogRepository pointLogRepository) {
         this.helloCallRepository = helloCallRepository;
         this.timeSlotRepository = timeSlotRepository;
         this.seniorRepository = seniorRepository;
         this.memberRepository = memberRepository;
         this.sinittoRepository = sinittoRepository;
         this.helloCallTimeLogRepository = helloCallTimeLogRepository;
+        this.pointRepository = pointRepository;
+        this.pointLogRepository = pointLogRepository;
     }
 
     @Transactional
@@ -224,9 +233,10 @@ public class HelloCallService {
 
         helloCall.changeStatusToComplete();
 
-        Sinitto earnedSinitto = helloCall.getSinitto();
-
-        //earnedSinitto에게 포인트 지급 로직 필요합니다.
+        Point sinittoPoint = pointRepository.findByMember(helloCall.getSinitto().getMember())
+                .orElseThrow(() -> new PointNotFoundException("포인트 적립 받을 시니또와 연관된 포인트가 없습니다"));
+        sinittoPoint.earn(helloCall.getPrice());
+        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN.getMessage(), sinittoPoint.getMember(), helloCall.getPrice(), PointLog.Status.EARN));
     }
 
 

--- a/src/main/java/com/example/sinitto/member/entity/Member.java
+++ b/src/main/java/com/example/sinitto/member/entity/Member.java
@@ -37,6 +37,11 @@ public class Member {
         this.phoneNumber = phoneNumber;
     }
 
+    public String getDepositMessage() {
+
+        return name.substring(0, 3) + phoneNumber.substring(phoneNumber.length() - 4);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/example/sinitto/member/service/MemberService.java
+++ b/src/main/java/com/example/sinitto/member/service/MemberService.java
@@ -12,10 +12,9 @@ import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.exception.NotUniqueException;
 import com.example.sinitto.member.repository.MemberRepository;
-import org.springframework.data.redis.core.RedisTemplate;
 import com.example.sinitto.point.entity.Point;
-import com.example.sinitto.point.repository.PointLogRepository;
 import com.example.sinitto.point.repository.PointRepository;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -28,19 +27,15 @@ public class MemberService implements MemberIdProvider {
     private final KakaoApiService kakaoApiService;
     private final KakaoTokenService kakaoTokenService;
     private final PointRepository pointRepository;
-    private final PointLogRepository pointLogRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
-
-    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService
-            ,RedisTemplate<String, String> redisTemplate) {
-    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, PointLogRepository pointLogRepository) {
+    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, RedisTemplate<String, String> redisTemplate) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
         this.kakaoApiService = kakaoApiService;
         this.kakaoTokenService = kakaoTokenService;
         this.pointRepository = pointRepository;
-        this.pointLogRepository = pointLogRepository;
+        this.redisTemplate = redisTemplate;
     }
 
     @Override

--- a/src/main/java/com/example/sinitto/member/service/MemberService.java
+++ b/src/main/java/com/example/sinitto/member/service/MemberService.java
@@ -12,6 +12,9 @@ import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.exception.NotUniqueException;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -23,12 +26,16 @@ public class MemberService implements MemberIdProvider {
     private final TokenService tokenService;
     private final KakaoApiService kakaoApiService;
     private final KakaoTokenService kakaoTokenService;
+    private final PointRepository pointRepository;
+    private final PointLogRepository pointLogRepository;
 
-    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService) {
+    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, PointLogRepository pointLogRepository) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
         this.kakaoApiService = kakaoApiService;
         this.kakaoTokenService = kakaoTokenService;
+        this.pointRepository = pointRepository;
+        this.pointLogRepository = pointLogRepository;
     }
 
     @Override
@@ -69,6 +76,8 @@ public class MemberService implements MemberIdProvider {
 
         Member newMember = new Member(name, phoneNumber, email, isSinitto);
         memberRepository.save(newMember);
+
+        pointRepository.save(new Point(0, newMember));
 
         String accessToken = tokenService.generateAccessToken(email);
         String refreshToken = tokenService.generateRefreshToken(email);

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -1,0 +1,66 @@
+package com.example.sinitto.point.controller;
+
+import com.example.sinitto.member.entity.Sinitto;
+import com.example.sinitto.point.dto.PointLogWithBankAccountNumber;
+import com.example.sinitto.point.entity.PointLog;
+import com.example.sinitto.point.service.PointAdminService;
+import com.example.sinitto.sinitto.exception.SinittoNotFoundException;
+import com.example.sinitto.sinitto.repository.SinittoRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class PointAdminController {
+
+    private final SinittoRepository sinittoRepository;
+    private final PointAdminService pointAdminService;
+
+    public PointAdminController(SinittoRepository sinittoRepository, PointAdminService pointAdminService) {
+        this.sinittoRepository = sinittoRepository;
+        this.pointAdminService = pointAdminService;
+    }
+
+    @GetMapping("/admin/point")
+    public String showAll(Model model) {
+
+        List<PointLog> pointLogs = pointAdminService.readAllNotCompletedPointChargeRequest();
+        List<PointLogWithBankAccountNumber> logWithBankAccountNumbers = new ArrayList<>();
+
+        for (PointLog pointLog : pointLogs) {
+            Sinitto sinitto = sinittoRepository.findByMemberId(pointLog.getMember().getId())
+                    .orElseThrow(() -> new SinittoNotFoundException("시니또를 찾을 수 없습니다"));
+
+            PointLogWithBankAccountNumber pointLogWithBankAccountNumber = new PointLogWithBankAccountNumber(
+                    pointLog.getId(),
+                    pointLog.getPrice(),
+                    pointLog.getPostTime(),
+                    pointLog.getStatus(),
+                    sinitto.getAccountNumber());
+
+            logWithBankAccountNumbers.add(pointLogWithBankAccountNumber);
+        }
+        model.addAttribute("logWithBankAccountNumbers", logWithBankAccountNumbers);
+
+        return "/point/charge";
+    }
+
+    @PostMapping("/admin/point/waiting/{pointLogId}")
+    public String changeToWaiting(@PathVariable Long pointLogId) {
+
+        pointAdminService.changePointLogChargeRequestToChargeWaiting(pointLogId);
+        return "redirect:/admin/point";
+    }
+
+    @PostMapping("/admin/point/complete/{pointLogId}")
+    public String changeToComplete(@PathVariable Long pointLogId) {
+
+        pointAdminService.changePointLogChargeWaitingToChargeComplete(pointLogId);
+        return "redirect:/admin/point";
+    }
+}

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -1,11 +1,15 @@
 package com.example.sinitto.point.controller;
 
 import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Sinitto;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointLogWithBankInfo;
 import com.example.sinitto.point.dto.PointLogWithDepositMessage;
 import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.service.PointAdminService;
+import com.example.sinitto.sinitto.exception.SinittoNotFoundException;
+import com.example.sinitto.sinitto.repository.SinittoRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,10 +24,12 @@ public class PointAdminController {
 
     private final PointAdminService pointAdminService;
     private final MemberRepository memberRepository;
+    private final SinittoRepository sinittoRepository;
 
-    public PointAdminController(PointAdminService pointAdminService, MemberRepository memberRepository) {
+    public PointAdminController(PointAdminService pointAdminService, MemberRepository memberRepository, SinittoRepository sinittoRepository) {
         this.pointAdminService = pointAdminService;
         this.memberRepository = memberRepository;
+        this.sinittoRepository = sinittoRepository;
     }
 
     @GetMapping("/admin/point/charge")
@@ -70,6 +76,53 @@ public class PointAdminController {
 
         pointAdminService.failPointCharge(pointLogId);
         return "redirect:/admin/point/charge";
+    }
+
+    @GetMapping("/admin/point/withdraw")
+    public String showAllWithdrawRequest(Model model) {
+
+        List<PointLog> pointLogs = pointAdminService.readAllPointWithdrawRequest();
+        List<PointLogWithBankInfo> logWithBankInfos = new ArrayList<>();
+
+        for (PointLog pointLog : pointLogs) {
+            Sinitto sinitto = sinittoRepository.findByMemberId(pointLog.getMember().getId())
+                    .orElseThrow(() -> new SinittoNotFoundException("시니또를 찾을 수 없습니다"));
+
+            PointLogWithBankInfo pointLogWithBankInfo = new PointLogWithBankInfo(
+                    pointLog.getId(),
+                    pointLog.getPrice(),
+                    pointLog.getPostTime(),
+                    pointLog.getStatus(),
+                    sinitto.getBankName(),
+                    sinitto.getAccountNumber()
+            );
+
+            logWithBankInfos.add(pointLogWithBankInfo);
+        }
+        model.addAttribute("logWithBankInfos", logWithBankInfos);
+
+        return "/point/withdraw";
+    }
+
+    @PostMapping("/admin/point/withdraw/waiting/{pointLogId}")
+    public String changeWithdrawLogToWaiting(@PathVariable Long pointLogId) {
+
+        pointAdminService.changeWithdrawLogToWaiting(pointLogId);
+        return "redirect:/admin/point/withdraw";
+    }
+
+    @PostMapping("/admin/point/withdraw/complete/{pointLogId}")
+    public String changeWithdrawLogToCompleteAndEarn(@PathVariable Long pointLogId) {
+
+        pointAdminService.changeWithdrawLogToComplete(pointLogId);
+        return "redirect:/admin/point/withdraw";
+    }
+
+    @PostMapping("/admin/point/withdraw/fail/{pointLogId}")
+    public String changeWithdrawLogToFail(@PathVariable Long pointLogId) {
+
+        pointAdminService.changeWithdrawLogToFail(pointLogId);
+        return "redirect:/admin/point/withdraw";
     }
 
 }

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -26,8 +26,8 @@ public class PointAdminController {
         this.pointAdminService = pointAdminService;
     }
 
-    @GetMapping("/admin/point")
-    public String showAll(Model model) {
+    @GetMapping("/admin/point/charge")
+    public String showAllChargeRequest(Model model) {
 
         List<PointLog> pointLogs = pointAdminService.readAllNotCompletedPointChargeRequest();
         List<PointLogWithBankAccountNumber> logWithBankAccountNumbers = new ArrayList<>();
@@ -50,18 +50,18 @@ public class PointAdminController {
         return "/point/charge";
     }
 
-    @PostMapping("/admin/point/waiting/{pointLogId}")
+    @PostMapping("/admin/point/charge/waiting/{pointLogId}")
     public String changeToWaiting(@PathVariable Long pointLogId) {
 
         pointAdminService.changePointLogChargeRequestToChargeWaiting(pointLogId);
-        return "redirect:/admin/point";
+        return "redirect:/admin/point/charge";
     }
 
-    @PostMapping("/admin/point/complete/{pointLogId}")
+    @PostMapping("/admin/point/charge/complete/{pointLogId}")
     public String changeToCompleteAndEarn(@PathVariable Long pointLogId) {
 
         pointAdminService.earnPoint(pointLogId);
         pointAdminService.changePointLogChargeWaitingToChargeComplete(pointLogId);
-        return "redirect:/admin/point";
+        return "redirect:/admin/point/charge";
     }
 }

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -60,7 +60,7 @@ public class PointAdminController {
     @PostMapping("/admin/point/charge/waiting/{pointLogId}")
     public String changeToWaiting(@PathVariable Long pointLogId) {
 
-        pointAdminService.changePointLogChargeRequestToChargeWaiting(pointLogId);
+        pointAdminService.changeChargeLogToWaiting(pointLogId);
         return "redirect:/admin/point/charge";
     }
 
@@ -74,7 +74,7 @@ public class PointAdminController {
     @PostMapping("/admin/point/charge/fail/{pointLogId}")
     public String changeToFail(@PathVariable Long pointLogId) {
 
-        pointAdminService.failPointCharge(pointLogId);
+        pointAdminService.changeChargeLogToFail(pointLogId);
         return "redirect:/admin/point/charge";
     }
 

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -58,8 +58,9 @@ public class PointAdminController {
     }
 
     @PostMapping("/admin/point/complete/{pointLogId}")
-    public String changeToComplete(@PathVariable Long pointLogId) {
+    public String changeToCompleteAndEarn(@PathVariable Long pointLogId) {
 
+        pointAdminService.earnPoint(pointLogId);
         pointAdminService.changePointLogChargeWaitingToChargeComplete(pointLogId);
         return "redirect:/admin/point";
     }

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.point.controller;
 
 import com.example.sinitto.point.exception.InvalidPointLogStatusException;
+import com.example.sinitto.point.exception.PointLogNotFoundException;
 import com.example.sinitto.point.exception.PointNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -29,5 +30,14 @@ public class PointAdminControllerAdvice {
         problemDetail.setType(URI.create("/errors/conflict"));
         problemDetail.setTitle("Conflict");
         return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+    }
+
+    @ExceptionHandler(PointLogNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handlePointLogNotFoundException(PointLogNotFoundException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setType(URI.create("/errors/not-found"));
+        problemDetail.setTitle("Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
 }

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminControllerAdvice.java
@@ -1,0 +1,33 @@
+package com.example.sinitto.point.controller;
+
+import com.example.sinitto.point.exception.InvalidPointStatusException;
+import com.example.sinitto.point.exception.PointNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.net.URI;
+
+@ControllerAdvice(basePackages = "com.example.sinitto.point")
+public class PointAdminControllerAdvice {
+
+    @ExceptionHandler(PointNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handlePointNotFoundException(PointNotFoundException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setType(URI.create("/errors/not-found"));
+        problemDetail.setTitle("Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+    }
+
+    @ExceptionHandler(InvalidPointStatusException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidPointStatusException(InvalidPointStatusException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
+        problemDetail.setType(URI.create("/errors/conflict"));
+        problemDetail.setTitle("Conflict");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+    }
+}

--- a/src/main/java/com/example/sinitto/point/controller/PointAdminControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminControllerAdvice.java
@@ -1,6 +1,6 @@
 package com.example.sinitto.point.controller;
 
-import com.example.sinitto.point.exception.InvalidPointStatusException;
+import com.example.sinitto.point.exception.InvalidPointLogStatusException;
 import com.example.sinitto.point.exception.PointNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -22,8 +22,8 @@ public class PointAdminControllerAdvice {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
 
-    @ExceptionHandler(InvalidPointStatusException.class)
-    public ResponseEntity<ProblemDetail> handleInvalidPointStatusException(InvalidPointStatusException e) {
+    @ExceptionHandler(InvalidPointLogStatusException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidPointStatusException(InvalidPointLogStatusException e) {
 
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
         problemDetail.setType(URI.create("/errors/conflict"));

--- a/src/main/java/com/example/sinitto/point/controller/PointController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointController.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.point.controller;
 
 import com.example.sinitto.common.annotation.MemberId;
+import com.example.sinitto.point.dto.PointChargeResponse;
 import com.example.sinitto.point.dto.PointLogResponse;
 import com.example.sinitto.point.dto.PointRequest;
 import com.example.sinitto.point.dto.PointResponse;
@@ -32,15 +33,13 @@ public class PointController {
         return ResponseEntity.ok(pointService.getPoint(memberId));
     }
 
-    @Operation(summary = "포인트 충전 요청", description = "(임시) 관리자가 직접 추가 - 바로 충전 되는거 아님. 신청->대기->완료 완료시점에 충전 됨")
+    @Operation(summary = "포인트 충전 요청", description = "관리자가 직접 추가 - 바로 충전 되는거 아님. 신청->대기->완료 완료시점에 충전 됨")
     @PutMapping("/charge")
-    public ResponseEntity<Void> savePointChargeRequest(@MemberId Long memberId,
-                                                       @RequestBody PointRequest request) {
+    public ResponseEntity<PointChargeResponse> savePointChargeRequest(@MemberId Long memberId,
+                                                                      @RequestBody PointRequest request) {
 
-        pointService.savePointChargeRequest(memberId, request.price());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(pointService.savePointChargeRequest(memberId, request.price()));
     }
-
 
     @Operation(summary = "포인트 출금 요청", description = "시니또가 포인트 출금을 요청합니다.")
     @PostMapping("/withdraw")

--- a/src/main/java/com/example/sinitto/point/controller/PointController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointController.java
@@ -32,6 +32,16 @@ public class PointController {
         return ResponseEntity.ok(pointService.getPoint(memberId));
     }
 
+    @Operation(summary = "포인트 충전 요청", description = "(임시) 관리자가 직접 추가 - 바로 충전 되는거 아님. 신청->대기->완료 완료시점에 충전 됨")
+    @PutMapping("/charge")
+    public ResponseEntity<Void> savePointChargeRequest(@MemberId Long memberId,
+                                                       @RequestBody PointRequest request) {
+
+        pointService.savePointChargeRequest(memberId, request.price());
+        return ResponseEntity.ok().build();
+    }
+
+
     @Operation(summary = "포인트 출금 요청", description = "시니또가 포인트 출금을 요청합니다.")
     @PostMapping("/withdraw")
     public ResponseEntity<String> requestPointWithdraw(@RequestBody PointRequest request) {

--- a/src/main/java/com/example/sinitto/point/controller/PointController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointController.java
@@ -7,22 +7,22 @@ import com.example.sinitto.point.dto.PointResponse;
 import com.example.sinitto.point.service.PointService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/points")
 @Tag(name = "포인트", description = "포인트 API")
 public class PointController {
 
-    @Operation(summary = "포인트 추가", description = "(임시) 관리자가 직접 추가 - 이후 외부 결제 api 연동")
-    @PutMapping("/add")
-    public ResponseEntity<String> addPoints(@RequestBody PointRequest request) {
-        // 임시 응답
-        return ResponseEntity.ok("포인트가 추가되었습니다.");
+    private final PointService pointService;
+
+    public PointController(PointService pointService) {
+        this.pointService = pointService;
     }
 
     @Operation(summary = "포인트 조회", description = "시니또, 보호자가 본인의 포인트를 조회합니다.")
@@ -41,9 +41,10 @@ public class PointController {
 
     @Operation(summary = "포인트 로그 조회", description = "포인트 로그를 조회합니다.")
     @GetMapping("/logs")
-    public ResponseEntity<List<PointLogResponse>> getPointLogs() {
-        // 임시 응답
-        return ResponseEntity.ok(new ArrayList<>());
+    public ResponseEntity<Page<PointLogResponse>> getPointLogs(@MemberId Long memberId,
+                                                               @PageableDefault(sort = "postTime", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(pointService.getPointLogs(memberId, pageable));
     }
 
 }

--- a/src/main/java/com/example/sinitto/point/controller/PointController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointController.java
@@ -43,9 +43,11 @@ public class PointController {
 
     @Operation(summary = "포인트 출금 요청", description = "시니또가 포인트 출금을 요청합니다.")
     @PostMapping("/withdraw")
-    public ResponseEntity<String> requestPointWithdraw(@RequestBody PointRequest request) {
-        // 임시 응답
-        return ResponseEntity.ok("포인트 출금 요청이 완료되었습니다.");
+    public ResponseEntity<Void> savePointWithdrawRequest(@MemberId Long memberId,
+                                                         @RequestBody PointRequest request) {
+
+        pointService.savePointWithdrawRequest(memberId, request.price());
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "포인트 로그 조회", description = "포인트 로그를 조회합니다.")

--- a/src/main/java/com/example/sinitto/point/controller/PointController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointController.java
@@ -1,8 +1,10 @@
 package com.example.sinitto.point.controller;
 
+import com.example.sinitto.common.annotation.MemberId;
 import com.example.sinitto.point.dto.PointLogResponse;
 import com.example.sinitto.point.dto.PointRequest;
 import com.example.sinitto.point.dto.PointResponse;
+import com.example.sinitto.point.service.PointService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/points")
-@Tag(name = "[미구현]포인트", description = "포인트 API")
+@Tag(name = "포인트", description = "포인트 API")
 public class PointController {
 
     @Operation(summary = "포인트 추가", description = "(임시) 관리자가 직접 추가 - 이후 외부 결제 api 연동")
@@ -23,18 +25,11 @@ public class PointController {
         return ResponseEntity.ok("포인트가 추가되었습니다.");
     }
 
-    @Operation(summary = "포인트 차감", description = "요청사항 등록 시 포인트를 차감합니다.")
-    @PutMapping("/deduct")
-    public ResponseEntity<String> deductPoints(@RequestBody PointRequest request) {
-        // 임시 응답
-        return ResponseEntity.ok("포인트가 차감되었습니다.");
-    }
-
     @Operation(summary = "포인트 조회", description = "시니또, 보호자가 본인의 포인트를 조회합니다.")
     @GetMapping()
-    public ResponseEntity<PointResponse> getPoint() {
-        // 임시 응답
-        return ResponseEntity.ok(new PointResponse(1000));
+    public ResponseEntity<PointResponse> getPoint(@MemberId Long memberId) {
+
+        return ResponseEntity.ok(pointService.getPoint(memberId));
     }
 
     @Operation(summary = "포인트 출금 요청", description = "시니또가 포인트 출금을 요청합니다.")

--- a/src/main/java/com/example/sinitto/point/controller/PointControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointControllerAdvice.java
@@ -1,0 +1,24 @@
+package com.example.sinitto.point.controller;
+
+import com.example.sinitto.point.exception.PointNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice(basePackages = "com.example.sinitto.point")
+public class PointControllerAdvice {
+
+    @ExceptionHandler(PointNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handlePointNotFoundException(PointNotFoundException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setType(URI.create("/errors/not-found"));
+        problemDetail.setTitle("Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+    }
+
+}

--- a/src/main/java/com/example/sinitto/point/controller/PointControllerAdvice.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.point.controller;
 
+import com.example.sinitto.point.exception.NotEnoughPointException;
 import com.example.sinitto.point.exception.PointNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -21,4 +22,12 @@ public class PointControllerAdvice {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
 
+    @ExceptionHandler(NotEnoughPointException.class)
+    public ResponseEntity<ProblemDetail> handleNotEnoughPointException(NotEnoughPointException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
+        problemDetail.setType(URI.create("/errors/conflict"));
+        problemDetail.setTitle("Conflict");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+    }
 }

--- a/src/main/java/com/example/sinitto/point/dto/PointChargeResponse.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointChargeResponse.java
@@ -1,0 +1,6 @@
+package com.example.sinitto.point.dto;
+
+public record PointChargeResponse(
+        String depositMessage
+) {
+}

--- a/src/main/java/com/example/sinitto/point/dto/PointLogResponse.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogResponse.java
@@ -8,5 +8,6 @@ public record PointLogResponse(
         LocalDateTime postTime,
         String content,
         int price,
-        PointLog.Status status) {
+        PointLog.Status status
+) {
 }

--- a/src/main/java/com/example/sinitto/point/dto/PointLogResponse.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogResponse.java
@@ -1,10 +1,12 @@
 package com.example.sinitto.point.dto;
 
+import com.example.sinitto.point.entity.PointLog;
+
 import java.time.LocalDateTime;
 
 public record PointLogResponse(
         LocalDateTime postTime,
-        String requirementContent,
+        String content,
         int price,
-        String type) {
+        PointLog.Status status) {
 }

--- a/src/main/java/com/example/sinitto/point/dto/PointLogWithBankAccountNumber.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogWithBankAccountNumber.java
@@ -1,0 +1,14 @@
+package com.example.sinitto.point.dto;
+
+import com.example.sinitto.point.entity.PointLog;
+
+import java.time.LocalDateTime;
+
+public record PointLogWithBankAccountNumber(
+        Long pointLogId,
+        Integer price,
+        LocalDateTime postTime,
+        PointLog.Status type,
+        String bankAccountNumber
+) {
+}

--- a/src/main/java/com/example/sinitto/point/dto/PointLogWithBankInfo.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogWithBankInfo.java
@@ -4,11 +4,12 @@ import com.example.sinitto.point.entity.PointLog;
 
 import java.time.LocalDateTime;
 
-public record PointLogWithBankAccountNumber(
+public record PointLogWithBankInfo(
         Long pointLogId,
-        Integer price,
+        int price,
         LocalDateTime postTime,
-        PointLog.Status type,
+        PointLog.Status status,
+        String bankName,
         String bankAccountNumber
 ) {
 }

--- a/src/main/java/com/example/sinitto/point/dto/PointLogWithDepositMessage.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogWithDepositMessage.java
@@ -1,0 +1,14 @@
+package com.example.sinitto.point.dto;
+
+import com.example.sinitto.point.entity.PointLog;
+
+import java.time.LocalDateTime;
+
+public record PointLogWithDepositMessage(
+        Long pointLogId,
+        int price,
+        LocalDateTime postTime,
+        PointLog.Status status,
+        String depositMessage
+) {
+}

--- a/src/main/java/com/example/sinitto/point/dto/PointRequest.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointRequest.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.point.dto;
 
 public record PointRequest(
-        int price) {
+        int price
+) {
 }

--- a/src/main/java/com/example/sinitto/point/dto/PointResponse.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointResponse.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.point.dto;
 
 public record PointResponse(
-        int price) {
+        int price
+) {
 }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -20,4 +20,12 @@ public class Point {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
+    public Point(int price, Member member) {
+        this.price = price;
+        this.member = member;
+    }
+
+    protected Point() {
+
+    }
 }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -37,8 +37,21 @@ public class Point {
         return member;
     }
 
-    public void earn(int earnedPrice) {
-        this.price += earnedPrice;
+    public void earn(int priceToAdd) {
+
+        this.price += priceToAdd;
     }
 
+    public void deduct(int priceToDeduct) {
+
+        this.price -= priceToDeduct;
+    }
+
+    public boolean isSufficientForDeduction(int priceToDeduct) {
+
+        if (this.price < priceToDeduct) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.point.exception.NotEnoughPointException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.OnDelete;
@@ -43,6 +44,10 @@ public class Point {
     }
 
     public void deduct(int priceToDeduct) {
+
+        if (this.price < priceToDeduct) {
+            throw new NotEnoughPointException(String.format("보유한 포인트(%d) 보다 더 많은 포인트에 대한 출금요청입니다", this.price));
+        }
 
         this.price -= priceToDeduct;
     }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -28,4 +28,8 @@ public class Point {
     protected Point() {
 
     }
+
+    public int getPrice() {
+        return price;
+    }
 }

--- a/src/main/java/com/example/sinitto/point/entity/Point.java
+++ b/src/main/java/com/example/sinitto/point/entity/Point.java
@@ -32,4 +32,13 @@ public class Point {
     public int getPrice() {
         return price;
     }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void earn(int earnedPrice) {
+        this.price += earnedPrice;
+    }
+
 }

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -59,6 +59,13 @@ public class PointLog {
         this.status = Status.CHARGE_COMPLETE;
     }
 
+    public void changeStatusToChargeFail() {
+
+        checkStatusChange(Status.CHARGE_WAITING);
+
+        this.status = Status.CHARGE_FAIL;
+    }
+
     private void checkStatusChange(Status wantStatus) {
 
         if (this.status != wantStatus) {
@@ -100,7 +107,8 @@ public class PointLog {
         WITHDRAW_COMPLETE,
         CHARGE_REQUEST,
         CHARGE_WAITING,
-        CHARGE_COMPLETE
+        CHARGE_COMPLETE,
+        CHARGE_FAIL
     }
 
     public enum Content {
@@ -108,7 +116,9 @@ public class PointLog {
         COMPLETE_HELLO_CALL_AND_EARN("안부 전화 완료로 인한 포인트 적립"),
         SPEND_COMPLETE_CALLBACK("콜백 신청으로 인한 포인트 차감"),
         SPEND_COMPLETE_HELLO_CALL("안부전화 신청으로 인한 포인트 차감"),
-        SPEND_CANCEL_HELLO_CALL("안부전화 신청 취소로 인한 포인트 환불");
+        SPEND_CANCEL_HELLO_CALL("안부전화 신청 취소로 인한 포인트 환불"),
+        CHARGE_REQUEST("포인트 충전 요청"),
+        WITHDRAW_REQUEST("포인트 출금 요청");
 
         private final String message;
 

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -22,11 +22,64 @@ public class PointLog {
     @CreatedDate
     private LocalDateTime postTime;
     @NotNull
-    private String type;
+    @Enumerated(EnumType.STRING)
+    private PointLog.Status status;
+    @NotNull
+    String content;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
+
+
+    public PointLog(String content, Member member, int price, Status status) {
+        this.content = content;
+        this.member = member;
+        this.price = price;
+        this.status = status;
+    }
+
+    protected PointLog() {
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public LocalDateTime getPostTime() {
+        return postTime;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public enum Status {
+        EARN,
+        SPEND_RESERVE,
+        SPEND_COMPLETE,
+        SPEND_CANCEL,
+        REFUND,
+        WITHDRAW_REQUEST,
+        WITHDRAW_WAITING,
+        WITHDRAW_COMPLETE,
+        CHARGE_REQUEST,
+        CHARGE_WAITING,
+        CHARGE_COMPLETE
+    }
 
 }

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -66,6 +66,27 @@ public class PointLog {
         this.status = Status.CHARGE_FAIL;
     }
 
+    public void changeStatusToWithdrawWaiting() {
+
+        checkStatusChange(Status.WITHDRAW_REQUEST);
+
+        this.status = Status.WITHDRAW_WAITING;
+    }
+
+    public void changeStatusToWithdrawComplete() {
+
+        checkStatusChange(Status.WITHDRAW_WAITING);
+
+        this.status = Status.WITHDRAW_COMPLETE;
+    }
+
+    public void changeStatusToWithdrawFail() {
+
+        checkStatusChange(Status.WITHDRAW_WAITING);
+
+        this.status = Status.WITHDRAW_FAIL_AND_RESTORE_POINT;
+    }
+
     private void checkStatusChange(Status wantStatus) {
 
         if (this.status != wantStatus) {
@@ -105,6 +126,7 @@ public class PointLog {
         WITHDRAW_REQUEST,
         WITHDRAW_WAITING,
         WITHDRAW_COMPLETE,
+        WITHDRAW_FAIL_AND_RESTORE_POINT,
         CHARGE_REQUEST,
         CHARGE_WAITING,
         CHARGE_COMPLETE,

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -122,7 +122,6 @@ public class PointLog {
         EARN,
         SPEND_COMPLETE,
         SPEND_CANCEL,
-        REFUND,
         WITHDRAW_REQUEST,
         WITHDRAW_WAITING,
         WITHDRAW_COMPLETE,

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class PointLog {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -103,6 +102,21 @@ public class PointLog {
         CHARGE_REQUEST,
         CHARGE_WAITING,
         CHARGE_COMPLETE
+    }
+
+    public enum Content {
+        COMPLETE_CALLBACK_AND_EARN("콜백 완료로 인한 포인트 적립"),
+        COMPLETE_HELLO_CALL_AND_EARN("안부 전화 완료로 인한 포인트 적립");
+
+        private final String message;
+
+        Content(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
     }
 
 }

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.point.exception.InvalidPointStatusException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.OnDelete;
@@ -14,9 +15,12 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class PointLog {
 
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NotNull
+    private String content;
     @NotNull
     private int price;
     @CreatedDate
@@ -24,8 +28,6 @@ public class PointLog {
     @NotNull
     @Enumerated(EnumType.STRING)
     private PointLog.Status status;
-    @NotNull
-    String content;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull
@@ -42,6 +44,27 @@ public class PointLog {
 
     protected PointLog() {
 
+    }
+
+    public void changeStatusToChargeWaiting() {
+
+        checkStatusChange(Status.CHARGE_REQUEST);
+
+        this.status = Status.CHARGE_WAITING;
+    }
+
+    public void changeStatusToChargeComplete() {
+
+        checkStatusChange(Status.CHARGE_WAITING);
+
+        this.status = Status.CHARGE_COMPLETE;
+    }
+
+    private void checkStatusChange(Status wantStatus) {
+
+        if (this.status != wantStatus) {
+            throw new InvalidPointStatusException(String.format("현재 %s 상태입니다. 이 상태에서는 %s 로의 전환이 불가합니다.", this.status, wantStatus));
+        }
     }
 
     public Long getId() {

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -1,7 +1,7 @@
 package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
-import com.example.sinitto.point.exception.InvalidPointStatusException;
+import com.example.sinitto.point.exception.InvalidPointLogStatusException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.OnDelete;
@@ -62,7 +62,7 @@ public class PointLog {
     private void checkStatusChange(Status wantStatus) {
 
         if (this.status != wantStatus) {
-            throw new InvalidPointStatusException(String.format("현재 %s 상태입니다. 이 상태에서는 %s 로의 전환이 불가합니다.", this.status, wantStatus));
+            throw new InvalidPointLogStatusException(String.format("현재 %s 상태입니다. 이 상태에서는 %s 로의 전환이 불가합니다.", this.status, wantStatus));
         }
     }
 
@@ -92,7 +92,6 @@ public class PointLog {
 
     public enum Status {
         EARN,
-        SPEND_RESERVE,
         SPEND_COMPLETE,
         SPEND_CANCEL,
         REFUND,
@@ -106,7 +105,10 @@ public class PointLog {
 
     public enum Content {
         COMPLETE_CALLBACK_AND_EARN("콜백 완료로 인한 포인트 적립"),
-        COMPLETE_HELLO_CALL_AND_EARN("안부 전화 완료로 인한 포인트 적립");
+        COMPLETE_HELLO_CALL_AND_EARN("안부 전화 완료로 인한 포인트 적립"),
+        SPEND_COMPLETE_CALLBACK("콜백 신청으로 인한 포인트 차감"),
+        SPEND_COMPLETE_HELLO_CALL("안부전화 신청으로 인한 포인트 차감"),
+        SPEND_CANCEL_HELLO_CALL("안부전화 신청 취소로 인한 포인트 환불");
 
         private final String message;
 

--- a/src/main/java/com/example/sinitto/point/exception/InvalidPointLogStatusException.java
+++ b/src/main/java/com/example/sinitto/point/exception/InvalidPointLogStatusException.java
@@ -1,0 +1,8 @@
+package com.example.sinitto.point.exception;
+
+public class InvalidPointLogStatusException extends RuntimeException {
+
+    public InvalidPointLogStatusException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/point/exception/InvalidPointLogStatusException.java
+++ b/src/main/java/com/example/sinitto/point/exception/InvalidPointLogStatusException.java
@@ -1,8 +1,0 @@
-package com.example.sinitto.point.exception;
-
-public class InvalidPointLogStatusException extends RuntimeException {
-
-    public InvalidPointLogStatusException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/example/sinitto/point/exception/InvalidPointStatusException.java
+++ b/src/main/java/com/example/sinitto/point/exception/InvalidPointStatusException.java
@@ -1,0 +1,8 @@
+package com.example.sinitto.point.exception;
+
+public class InvalidPointStatusException extends RuntimeException {
+
+    public InvalidPointStatusException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/point/exception/InvalidPointStatusException.java
+++ b/src/main/java/com/example/sinitto/point/exception/InvalidPointStatusException.java
@@ -1,8 +1,0 @@
-package com.example.sinitto.point.exception;
-
-public class InvalidPointStatusException extends RuntimeException {
-
-    public InvalidPointStatusException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/example/sinitto/point/exception/NotEnoughPointException.java
+++ b/src/main/java/com/example/sinitto/point/exception/NotEnoughPointException.java
@@ -1,0 +1,8 @@
+package com.example.sinitto.point.exception;
+
+public class NotEnoughPointException extends RuntimeException {
+
+    public NotEnoughPointException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/point/exception/PointLogNotFoundException.java
+++ b/src/main/java/com/example/sinitto/point/exception/PointLogNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.sinitto.point.exception;
+
+public class PointLogNotFoundException extends RuntimeException {
+
+    public PointLogNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sinitto/point/exception/PointNotFoundException.java
+++ b/src/main/java/com/example/sinitto/point/exception/PointNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.sinitto.point.exception;
+
+public class PointNotFoundException extends RuntimeException {
+
+    public PointNotFoundException(String message) {
+    }
+}

--- a/src/main/java/com/example/sinitto/point/exception/PointNotFoundException.java
+++ b/src/main/java/com/example/sinitto/point/exception/PointNotFoundException.java
@@ -3,5 +3,6 @@ package com.example.sinitto.point.exception;
 public class PointNotFoundException extends RuntimeException {
 
     public PointNotFoundException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
@@ -12,5 +12,5 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
 
     Page<PointLog> findAllByMember(Member member, Pageable pageable);
 
-    List<PointLog> findAllByStatusInOOrderByPostTimeDesc(List<PointLog.Status> statuses);
+    List<PointLog> findAllByStatusInOrderByPostTimeDesc(List<PointLog.Status> statuses);
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
@@ -12,5 +12,5 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
 
     Page<PointLog> findAllByMember(Member member, Pageable pageable);
 
-    List<PointLog> findAllByTypeIn(List<PointLog.Status> types);
+    List<PointLog> findAllByStatusIn(List<PointLog.Status> statuses);
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
@@ -1,0 +1,16 @@
+package com.example.sinitto.point.repository;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.point.entity.PointLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PointLogRepository extends JpaRepository<PointLog, Long> {
+
+    Page<PointLog> findAllByMember(Member member, Pageable pageable);
+
+    List<PointLog> findAllByTypeIn(List<PointLog.Status> types);
+}

--- a/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointLogRepository.java
@@ -12,5 +12,5 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
 
     Page<PointLog> findAllByMember(Member member, Pageable pageable);
 
-    List<PointLog> findAllByStatusIn(List<PointLog.Status> statuses);
+    List<PointLog> findAllByStatusInOOrderByPostTimeDesc(List<PointLog.Status> statuses);
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointRepository.java
@@ -9,4 +9,7 @@ import java.util.Optional;
 public interface PointRepository extends JpaRepository<Point, Long> {
 
     Optional<Point> findByMember(Member member);
+
+    Optional<Point> findByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointRepository.java
@@ -2,7 +2,10 @@ package com.example.sinitto.point.repository;
 
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.point.entity.Point;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -12,4 +15,7 @@ public interface PointRepository extends JpaRepository<Point, Long> {
 
     Optional<Point> findByMemberId(Long memberId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Point p WHERE p.member.id = :memberId")
+    Optional<Point> findByMemberIdWithWriteLock(Long memberId);
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointRepository.java
@@ -1,8 +1,12 @@
 package com.example.sinitto.point.repository;
 
+import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.point.entity.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PointRepository extends JpaRepository<Point, Long> {
 
+    Optional<Point> findByMember(Member member);
 }

--- a/src/main/java/com/example/sinitto/point/repository/PointRepository.java
+++ b/src/main/java/com/example/sinitto/point/repository/PointRepository.java
@@ -1,0 +1,8 @@
+package com.example.sinitto.point.repository;
+
+import com.example.sinitto.point.entity.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointRepository extends JpaRepository<Point, Long> {
+
+}

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -27,7 +27,7 @@ public class PointAdminService {
     }
 
     @Transactional
-    public void changePointLogChargeRequestToChargeWaiting(Long pointLogId) {
+    public void changeChargeLogToWaiting(Long pointLogId) {
 
         PointLog pointLog = pointLogRepository.findById(pointLogId)
                 .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다"));
@@ -49,7 +49,7 @@ public class PointAdminService {
     }
 
     @Transactional
-    public void failPointCharge(Long pointLogId) {
+    public void changeChargeLogToFail(Long pointLogId) {
 
         PointLog pointLog = pointLogRepository.findById(pointLogId)
                 .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -1,0 +1,42 @@
+package com.example.sinitto.point.service;
+
+import com.example.sinitto.point.entity.PointLog;
+import com.example.sinitto.point.exception.PointLogNotFoundException;
+import com.example.sinitto.point.repository.PointLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class PointAdminService {
+
+    private final PointLogRepository pointLogRepository;
+
+    public PointAdminService(PointLogRepository pointLogRepository) {
+        this.pointLogRepository = pointLogRepository;
+    }
+
+    public List<PointLog> readAllNotCompletedPointChargeRequest() {
+
+        return pointLogRepository.findAllByStatusIn(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST));
+    }
+
+    @Transactional
+    public void changePointLogChargeRequestToChargeWaiting(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다"));
+
+        pointLog.changeStatusToChargeWaiting();
+    }
+
+    @Transactional
+    public void changePointLogChargeWaitingToChargeComplete(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다"));
+
+        pointLog.changeStatusToChargeComplete();
+    }
+}

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -56,4 +56,42 @@ public class PointAdminService {
 
         pointLog.changeStatusToChargeFail();
     }
+
+    @Transactional(readOnly = true)
+    public List<PointLog> readAllPointWithdrawRequest() {
+
+        return pointLogRepository.findAllByStatusIn(List.of(PointLog.Status.WITHDRAW_REQUEST, PointLog.Status.WITHDRAW_WAITING));
+    }
+
+    @Transactional
+    public void changeWithdrawLogToWaiting(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));
+
+        pointLog.changeStatusToWithdrawWaiting();
+    }
+
+    @Transactional
+    public void changeWithdrawLogToComplete(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));
+
+        pointLog.changeStatusToWithdrawComplete();
+    }
+
+    @Transactional
+    public void changeWithdrawLogToFail(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));
+
+        Point point = pointRepository.findByMember(pointLog.getMember())
+                .orElseThrow(() -> new PointLogNotFoundException("포인트를 찾을 수 없습니다."));
+
+        point.earn(pointLog.getPrice());
+
+        pointLog.changeStatusToWithdrawFail();
+    }
 }

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -23,7 +23,7 @@ public class PointAdminService {
 
     public List<PointLog> readAllNotCompletedPointChargeRequest() {
 
-        return pointLogRepository.findAllByStatusInOOrderByPostTimeDesc(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST, PointLog.Status.CHARGE_COMPLETE, PointLog.Status.CHARGE_FAIL));
+        return pointLogRepository.findAllByStatusInOrderByPostTimeDesc(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST, PointLog.Status.CHARGE_COMPLETE, PointLog.Status.CHARGE_FAIL));
     }
 
     @Transactional
@@ -60,7 +60,7 @@ public class PointAdminService {
     @Transactional(readOnly = true)
     public List<PointLog> readAllPointWithdrawRequest() {
 
-        return pointLogRepository.findAllByStatusInOOrderByPostTimeDesc(List.of(PointLog.Status.WITHDRAW_REQUEST, PointLog.Status.WITHDRAW_WAITING, PointLog.Status.WITHDRAW_COMPLETE, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
+        return pointLogRepository.findAllByStatusInOrderByPostTimeDesc(List.of(PointLog.Status.WITHDRAW_REQUEST, PointLog.Status.WITHDRAW_WAITING, PointLog.Status.WITHDRAW_COMPLETE, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -36,16 +36,7 @@ public class PointAdminService {
     }
 
     @Transactional
-    public void changePointLogChargeWaitingToChargeComplete(Long pointLogId) {
-
-        PointLog pointLog = pointLogRepository.findById(pointLogId)
-                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다"));
-
-        pointLog.changeStatusToChargeComplete();
-    }
-
-    @Transactional
-    public void earnPoint(Long pointLogId) {
+    public void earnPointAndChangeToChargeComplete(Long pointLogId) {
 
         PointLog pointLog = pointLogRepository.findById(pointLogId)
                 .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));
@@ -53,6 +44,16 @@ public class PointAdminService {
         Point point = pointRepository.findByMember(pointLog.getMember())
                 .orElseThrow(() -> new PointLogNotFoundException("포인트를 찾을 수 없습니다."));
 
+        pointLog.changeStatusToChargeComplete();
         point.earn(pointLog.getPrice());
+    }
+
+    @Transactional
+    public void failPointCharge(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));
+
+        pointLog.changeStatusToChargeFail();
     }
 }

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -23,7 +23,7 @@ public class PointAdminService {
 
     public List<PointLog> readAllNotCompletedPointChargeRequest() {
 
-        return pointLogRepository.findAllByStatusIn(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST));
+        return pointLogRepository.findAllByStatusInOOrderByPostTimeDesc(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST, PointLog.Status.CHARGE_COMPLETE, PointLog.Status.CHARGE_FAIL));
     }
 
     @Transactional
@@ -60,7 +60,7 @@ public class PointAdminService {
     @Transactional(readOnly = true)
     public List<PointLog> readAllPointWithdrawRequest() {
 
-        return pointLogRepository.findAllByStatusIn(List.of(PointLog.Status.WITHDRAW_REQUEST, PointLog.Status.WITHDRAW_WAITING));
+        return pointLogRepository.findAllByStatusInOOrderByPostTimeDesc(List.of(PointLog.Status.WITHDRAW_REQUEST, PointLog.Status.WITHDRAW_WAITING, PointLog.Status.WITHDRAW_COMPLETE, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -1,8 +1,10 @@
 package com.example.sinitto.point.service;
 
+import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.exception.PointLogNotFoundException;
 import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,9 +14,11 @@ import java.util.List;
 public class PointAdminService {
 
     private final PointLogRepository pointLogRepository;
+    private final PointRepository pointRepository;
 
-    public PointAdminService(PointLogRepository pointLogRepository) {
+    public PointAdminService(PointLogRepository pointLogRepository, PointRepository pointRepository) {
         this.pointLogRepository = pointLogRepository;
+        this.pointRepository = pointRepository;
     }
 
     public List<PointLog> readAllNotCompletedPointChargeRequest() {
@@ -38,5 +42,17 @@ public class PointAdminService {
                 .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다"));
 
         pointLog.changeStatusToChargeComplete();
+    }
+
+    @Transactional
+    public void earnPoint(Long pointLogId) {
+
+        PointLog pointLog = pointLogRepository.findById(pointLogId)
+                .orElseThrow(() -> new PointLogNotFoundException("포인트 로그를 찾을 수 없습니다."));
+
+        Point point = pointRepository.findByMember(pointLog.getMember())
+                .orElseThrow(() -> new PointLogNotFoundException("포인트를 찾을 수 없습니다."));
+
+        point.earn(pointLog.getPrice());
     }
 }

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -75,7 +75,7 @@ public class PointService {
         Point point = pointRepository.findByMember(member)
                 .orElseThrow(() -> new PointNotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));
 
-        if(!point.isSufficientForDeduction(price)){
+        if (!point.isSufficientForDeduction(price)) {
             throw new NotEnoughPointException(String.format("보유한 포인트(%d) 보다 더 많은 포인트에 대한 출금요청입니다", point.getPrice()));
         }
 

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -1,0 +1,34 @@
+package com.example.sinitto.point.service;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.exception.MemberNotFoundException;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointResponse;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.exception.PointNotFoundException;
+import com.example.sinitto.point.repository.PointRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PointService {
+
+    private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
+
+    public PointService(MemberRepository memberRepository, PointRepository pointRepository) {
+        this.memberRepository = memberRepository;
+        this.pointRepository = pointRepository;
+    }
+
+    public PointResponse getPoint(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("요청한 멤버를 찾을 수 없습니다"));
+
+        Point point = pointRepository.findByMember(member)
+                .orElseThrow(()->new PointNotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));
+
+        return new PointResponse(point.getPrice());
+    }
+
+}

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class PointService {
 
+    public static final double WITHDRAWAL_FEE_RATE = 0.8;
     private final MemberRepository memberRepository;
     private final PointRepository pointRepository;
     private final PointLogRepository pointLogRepository;
@@ -75,12 +76,14 @@ public class PointService {
         Point point = pointRepository.findByMember(member)
                 .orElseThrow(() -> new PointNotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));
 
+        int adjustedPrice = (int) (price * WITHDRAWAL_FEE_RATE);
+
         if (!point.isSufficientForDeduction(price)) {
             throw new NotEnoughPointException(String.format("보유한 포인트(%d) 보다 더 많은 포인트에 대한 출금요청입니다", point.getPrice()));
         }
 
         point.deduct(price);
 
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST.getMessage(), member, price, PointLog.Status.WITHDRAW_REQUEST));
+        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST.getMessage(), member, adjustedPrice, PointLog.Status.WITHDRAW_REQUEST));
     }
 }

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -3,6 +3,7 @@ package com.example.sinitto.point.service;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointChargeResponse;
 import com.example.sinitto.point.dto.PointLogResponse;
 import com.example.sinitto.point.dto.PointResponse;
 import com.example.sinitto.point.entity.Point;
@@ -13,6 +14,7 @@ import com.example.sinitto.point.repository.PointRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PointService {
@@ -52,7 +54,18 @@ public class PointService {
                 ));
     }
 
-    public void savePointChargeRequest(Long memberId, int price) {
+    @Transactional
+    public PointChargeResponse savePointChargeRequest(Long memberId, int price) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("요청한 멤버를 찾을 수 없습니다"));
+
+        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST.getMessage(), member, price, PointLog.Status.CHARGE_REQUEST));
+
+        return new PointChargeResponse(member.getDepositMessage());
+    }
+
+    public void saverPointWithdrawRequest(Long memberId, int price) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("멤버 없음"));

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -3,10 +3,14 @@ package com.example.sinitto.point.service;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointLogResponse;
 import com.example.sinitto.point.dto.PointResponse;
 import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.exception.PointNotFoundException;
+import com.example.sinitto.point.repository.PointLogRepository;
 import com.example.sinitto.point.repository.PointRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,10 +18,12 @@ public class PointService {
 
     private final MemberRepository memberRepository;
     private final PointRepository pointRepository;
+    private final PointLogRepository pointLogRepository;
 
-    public PointService(MemberRepository memberRepository, PointRepository pointRepository) {
+    public PointService(MemberRepository memberRepository, PointRepository pointRepository, PointLogRepository pointLogRepository) {
         this.memberRepository = memberRepository;
         this.pointRepository = pointRepository;
+        this.pointLogRepository = pointLogRepository;
     }
 
     public PointResponse getPoint(Long memberId) {
@@ -26,9 +32,22 @@ public class PointService {
                 .orElseThrow(() -> new MemberNotFoundException("요청한 멤버를 찾을 수 없습니다"));
 
         Point point = pointRepository.findByMember(member)
-                .orElseThrow(()->new PointNotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));
+                .orElseThrow(() -> new PointNotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));
 
         return new PointResponse(point.getPrice());
     }
 
+    public Page<PointLogResponse> getPointLogs(Long memberId, Pageable pageable) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("요청한 멤버를 찾을 수 없습니다"));
+
+        return pointLogRepository.findAllByMember(member, pageable)
+                .map(pointLog -> new PointLogResponse(
+                        pointLog.getPostTime(),
+                        pointLog.getContent(),
+                        pointLog.getPrice(),
+                        pointLog.getStatus()
+                ));
+    }
 }

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -6,6 +6,7 @@ import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointLogResponse;
 import com.example.sinitto.point.dto.PointResponse;
 import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.exception.PointNotFoundException;
 import com.example.sinitto.point.repository.PointLogRepository;
 import com.example.sinitto.point.repository.PointRepository;
@@ -49,5 +50,13 @@ public class PointService {
                         pointLog.getPrice(),
                         pointLog.getStatus()
                 ));
+    }
+
+    public void savePointChargeRequest(Long memberId, int price) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("멤버 없음"));
+
+        pointLogRepository.save(new PointLog("포인트 충전 요청", member, price, PointLog.Status.CHARGE_REQUEST));
     }
 }

--- a/src/main/resources/static/css/point.css
+++ b/src/main/resources/static/css/point.css
@@ -1,0 +1,61 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    margin: 0;
+    padding: 20px;
+}
+
+h1 {
+    text-align: center;
+    color: #333;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+th, td {
+    padding: 12px;
+    text-align: left;
+    border: 1px solid #ddd;
+    background-color: #fff;
+}
+
+th {
+    background-color: #4CAF50;
+    color: white;
+}
+
+tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+
+tr:hover {
+    background-color: #f1f1f1;
+}
+
+button {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    padding: 10px 15px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 14px;
+    margin: 4px 2px;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #45a049;
+}
+
+form {
+    display: inline;
+}

--- a/src/main/resources/templates/point/charge.html
+++ b/src/main/resources/templates/point/charge.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="kr">
+<head>
+    <meta charset="UTF-8">
+    <title>충전 페이지</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 20px;
+        }
+
+        h1 {
+            text-align: center;
+            color: #333;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border: 1px solid #ddd;
+            background-color: #fff;
+        }
+
+        th {
+            background-color: #4CAF50;
+            color: white;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+
+        tr:hover {
+            background-color: #f1f1f1;
+        }
+
+        button {
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            padding: 10px 15px;
+            text-align: center;
+            text-decoration: none;
+            display: inline-block;
+            font-size: 14px;
+            margin: 4px 2px;
+            cursor: pointer;
+            border-radius: 4px;
+            transition: background-color 0.3s;
+        }
+
+        button:hover {
+            background-color: #45a049;
+        }
+
+        form {
+            display: inline;
+        }
+    </style>
+</head>
+<body>
+<div>
+    <table>
+        <thead>
+        <tr>
+            <th>요청 시간</th>
+            <th>요청된 포인트</th>
+            <th>계좌번호</th>
+            <th>상태</th>
+            <th>상태전환</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="logWithBankAccountNumber : ${logWithBankAccountNumbers}">
+            <td th:text="${logWithBankAccountNumber.postTime()}">요청 시간</td>
+            <td th:text="${logWithBankAccountNumber.price()}">요청된 포인트</td>
+            <td th:text="${logWithBankAccountNumber.bankAccountNumber()}">계좌번호</td>
+            <td th:text="${logWithBankAccountNumber.type().toString()}">상태</td>
+
+            <td>
+                <!-- 상태가 CHARGE_REQUEST일 때 -->
+                <form method="post"
+                      th:action="@{/admin/point/waiting/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
+                      th:if="${logWithBankAccountNumber.type().toString()} == 'CHARGE_REQUEST'">
+                    <button type="submit">대기 상태로 변경</button>
+                </form>
+
+                <!-- 상태가 CHARGE_WAITING일 때 -->
+                <form method="post"
+                      th:action="@{/admin/point/complete/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
+                      th:if="${logWithBankAccountNumber.type.toString()} == 'CHARGE_WAITING'">
+                    <button type="submit">포인트 지급 & 완료 상태로 변경</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/point/charge.html
+++ b/src/main/resources/templates/point/charge.html
@@ -12,31 +12,37 @@
         <tr>
             <th>요청 시간</th>
             <th>요청된 포인트</th>
-            <th>계좌번호</th>
+            <th>입금 메세지</th>
             <th>상태</th>
             <th>상태전환</th>
         </tr>
         </thead>
         <tbody>
-        <tr th:each="logWithBankAccountNumber : ${logWithBankAccountNumbers}">
-            <td th:text="${logWithBankAccountNumber.postTime()}">요청 시간</td>
-            <td th:text="${logWithBankAccountNumber.price()}">요청된 포인트</td>
-            <td th:text="${logWithBankAccountNumber.bankAccountNumber()}">계좌번호</td>
-            <td th:text="${logWithBankAccountNumber.type().toString()}">상태</td>
+        <tr th:each="logWithDepositMessage : ${logWithDepositMessages}">
+            <td th:text="${logWithDepositMessage.postTime}">요청 시간</td>
+            <td th:text="${logWithDepositMessage.price}">요청된 포인트</td>
+            <td th:text="${logWithDepositMessage.depositMessage}">입금 메세지</td>
+            <td th:text="${logWithDepositMessage.status().toString()}">상태</td>
 
             <td>
                 <!-- 상태가 CHARGE_REQUEST일 때 -->
                 <form method="post"
-                      th:action="@{/admin/point/charge/waiting/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
-                      th:if="${logWithBankAccountNumber.type().toString()} == 'CHARGE_REQUEST'">
+                      th:action="@{/admin/point/charge/waiting/{pointLogId}(pointLogId=${logWithDepositMessage.pointLogId})}"
+                      th:if="${logWithDepositMessage.status.toString()} == 'CHARGE_REQUEST'">
                     <button type="submit">대기 상태로 변경</button>
                 </form>
 
                 <!-- 상태가 CHARGE_WAITING일 때 -->
                 <form method="post"
-                      th:action="@{/admin/point/charge/complete/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
-                      th:if="${logWithBankAccountNumber.type.toString()} == 'CHARGE_WAITING'">
+                      th:action="@{/admin/point/charge/complete/{pointLogId}(pointLogId=${logWithDepositMessage.pointLogId})}"
+                      th:if="${logWithDepositMessage.status.toString()} == 'CHARGE_WAITING'">
                     <button type="submit">포인트 지급 & 완료 상태로 변경</button>
+                </form>
+                <!-- 상태가 CHARGE_WAITING일 때 -->
+                <form method="post"
+                      th:action="@{/admin/point/charge/fail/{pointLogId}(pointLogId=${logWithDepositMessage.pointLogId})}"
+                      th:if="${logWithDepositMessage.status.toString()} == 'CHARGE_WAITING'">
+                    <button type="submit">실패 상태로 변경</button>
                 </form>
             </td>
         </tr>

--- a/src/main/resources/templates/point/charge.html
+++ b/src/main/resources/templates/point/charge.html
@@ -2,70 +2,8 @@
 <html lang="kr">
 <head>
     <meta charset="UTF-8">
+    <link href="/css/point.css" rel="stylesheet">
     <title>충전 페이지</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #f4f4f4;
-            margin: 0;
-            padding: 20px;
-        }
-
-        h1 {
-            text-align: center;
-            color: #333;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 20px 0;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-        }
-
-        th, td {
-            padding: 12px;
-            text-align: left;
-            border: 1px solid #ddd;
-            background-color: #fff;
-        }
-
-        th {
-            background-color: #4CAF50;
-            color: white;
-        }
-
-        tr:nth-child(even) {
-            background-color: #f9f9f9;
-        }
-
-        tr:hover {
-            background-color: #f1f1f1;
-        }
-
-        button {
-            background-color: #4CAF50;
-            color: white;
-            border: none;
-            padding: 10px 15px;
-            text-align: center;
-            text-decoration: none;
-            display: inline-block;
-            font-size: 14px;
-            margin: 4px 2px;
-            cursor: pointer;
-            border-radius: 4px;
-            transition: background-color 0.3s;
-        }
-
-        button:hover {
-            background-color: #45a049;
-        }
-
-        form {
-            display: inline;
-        }
-    </style>
 </head>
 <body>
 <div>
@@ -89,14 +27,14 @@
             <td>
                 <!-- 상태가 CHARGE_REQUEST일 때 -->
                 <form method="post"
-                      th:action="@{/admin/point/waiting/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
+                      th:action="@{/admin/point/charge/waiting/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
                       th:if="${logWithBankAccountNumber.type().toString()} == 'CHARGE_REQUEST'">
                     <button type="submit">대기 상태로 변경</button>
                 </form>
 
                 <!-- 상태가 CHARGE_WAITING일 때 -->
                 <form method="post"
-                      th:action="@{/admin/point/complete/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
+                      th:action="@{/admin/point/charge/complete/{pointLogId}(pointLogId=${logWithBankAccountNumber.pointLogId()})}"
                       th:if="${logWithBankAccountNumber.type.toString()} == 'CHARGE_WAITING'">
                     <button type="submit">포인트 지급 & 완료 상태로 변경</button>
                 </form>

--- a/src/main/resources/templates/point/charge.html
+++ b/src/main/resources/templates/point/charge.html
@@ -38,6 +38,7 @@
                       th:if="${logWithDepositMessage.status.toString()} == 'CHARGE_WAITING'">
                     <button type="submit">포인트 지급 & 완료 상태로 변경</button>
                 </form>
+
                 <!-- 상태가 CHARGE_WAITING일 때 -->
                 <form method="post"
                       th:action="@{/admin/point/charge/fail/{pointLogId}(pointLogId=${logWithDepositMessage.pointLogId})}"

--- a/src/main/resources/templates/point/withdraw.html
+++ b/src/main/resources/templates/point/withdraw.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="kr">
+<head>
+    <meta charset="UTF-8">
+    <link href="/css/point.css" rel="stylesheet">
+    <title>출금 페이지</title>
+</head>
+<body>
+<div>
+    <table>
+        <thead>
+        <tr>
+            <th>출금 요청시간</th>
+            <th>출금 포인트</th>
+            <th>은행 이름</th>
+            <th>계좌번호</th>
+            <th>상태</th>
+            <th>상태전환</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="logWithBankInfo : ${logWithBankInfos}">
+            <td th:text="${logWithBankInfo.postTime()}">요청 시간</td>
+            <td th:text="${logWithBankInfo.price()}">요청된 포인트</td>
+            <td th:text="${logWithBankInfo.bankName()}">은행 이름</td>
+            <td th:text="${logWithBankInfo.bankAccountNumber()}">계좌번호</td>
+            <td th:text="${logWithBankInfo.status().toString()}">상태</td>
+
+            <td>
+                <!-- 상태가 WITHDRAW_REQUEST일 때 -->
+                <form method="post"
+                      th:action="@{/admin/point/withdraw/waiting/{pointLogId}(pointLogId=${logWithBankInfo.pointLogId()})}"
+                      th:if="${logWithBankInfo.status().toString()} == 'WITHDRAW_REQUEST'">
+                    <button type="submit">대기 상태로 변경</button>
+                </form>
+
+                <!-- 상태가 CHARGE_WAITING일 때 -->
+                <form method="post"
+                      th:action="@{/admin/point/withdraw/complete/{pointLogId}(pointLogId=${logWithBankInfo.pointLogId()})}"
+                      th:if="${logWithBankInfo.status().toString()} == 'WITHDRAW_WAITING'">
+                    <button type="submit">입금 완료 & 완료 상태로 변경</button>
+                </form>
+
+                <!-- 상태가 CHARGE_WAITING일 때 -->
+                <form method="post"
+                      th:action="@{/admin/point/charge/fail/{pointLogId}(pointLogId=${logWithBankInfo.pointLogId})}"
+                      th:if="${logWithBankInfo.status.toString()} == 'WITHDRAW_WAITING'">
+                    <button type="submit">실패 상태로 변경</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -12,6 +12,8 @@ import com.example.sinitto.guard.repository.SeniorRepository;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.repository.PointRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -38,6 +40,8 @@ class CallbackServiceTest {
     MemberRepository memberRepository;
     @Mock
     SeniorRepository seniorRepository;
+    @Mock
+    PointRepository pointRepository;
     @InjectMocks
     CallbackService callbackService;
 
@@ -66,7 +70,7 @@ class CallbackServiceTest {
 
         //then
         assertEquals(1, result.getContent().size());
-        assertEquals("James", result.getContent().get(0).seniorName());
+        assertEquals("James", result.getContent().getFirst().seniorName());
     }
 
     @Test
@@ -209,12 +213,14 @@ class CallbackServiceTest {
         Member member = mock(Member.class);
         Callback callback = mock(Callback.class);
         Senior senior = mock(Senior.class);
+        Point point = mock(Point.class);
 
         when(member.getId()).thenReturn(1L);
         when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
         when(callback.getSenior()).thenReturn(senior);
         when(senior.getMember()).thenReturn(member);
         when(senior.getMember().getId()).thenReturn(1L);
+        when(pointRepository.findByMemberId(any())).thenReturn(Optional.of(point));
 
         //when
         callbackService.complete(memberId, callbackId);

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -13,6 +13,7 @@ import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.repository.PointLogRepository;
 import com.example.sinitto.point.repository.PointRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,8 @@ class CallbackServiceTest {
     SeniorRepository seniorRepository;
     @Mock
     PointRepository pointRepository;
+    @Mock
+    PointLogRepository pointLogRepository;
     @InjectMocks
     CallbackService callbackService;
 
@@ -176,13 +179,19 @@ class CallbackServiceTest {
         String fromPhoneNumber = "+821012341234";
         String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
         Senior senior = mock(Senior.class);
+        Member member = mock(Member.class);
+        Point point = mock(Point.class);
 
         when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
-
+        when(senior.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(pointRepository.findByMemberIdWithWriteLock(1L)).thenReturn(Optional.of(point));
+        when(point.isSufficientForDeduction(anyInt())).thenReturn(true);
         //when
         String result = callbackService.add(fromPhoneNumber);
 
         //then
+        verify(pointLogRepository, times(1)).save(any());
         verify(callbackRepository, times(1)).save(any());
         assertNotNull(result);
     }

--- a/src/test/java/com/example/sinitto/point/entity/PointLogTest.java
+++ b/src/test/java/com/example/sinitto/point/entity/PointLogTest.java
@@ -2,7 +2,7 @@ package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
-import com.example.sinitto.point.exception.InvalidPointStatusException;
+import com.example.sinitto.point.exception.InvalidPointLogStatusException;
 import com.example.sinitto.point.repository.PointLogRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -41,13 +41,13 @@ class PointLogTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"EARN", "SPEND_RESERVE", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_WAITING", "CHARGE_COMPLETE"})
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_WAITING", "CHARGE_COMPLETE"})
     @DisplayName("포인트 로그 ChargeWaiting 상태로 전환 실패")
     void changeStatusToChargeWaiting_fail(String initialStatus) {
         PointLog.Status status = PointLog.Status.valueOf(initialStatus);
         PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, status));
 
-        assertThrows(InvalidPointStatusException.class, pointLog::changeStatusToChargeWaiting);
+        assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToChargeWaiting);
     }
 
     @Test
@@ -61,12 +61,12 @@ class PointLogTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"EARN", "SPEND_RESERVE", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_REQUEST", "CHARGE_COMPLETE"})
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_REQUEST", "CHARGE_COMPLETE"})
     @DisplayName("포인트 로그 ChargeComplete 상태로 전환 실패")
     void changeStatusToChargeComplete_fail(String initialStatus) {
         PointLog.Status status = PointLog.Status.valueOf(initialStatus);
         PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, status));
 
-        assertThrows(InvalidPointStatusException.class, pointLog::changeStatusToChargeComplete);
+        assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToChargeComplete);
     }
 }

--- a/src/test/java/com/example/sinitto/point/entity/PointLogTest.java
+++ b/src/test/java/com/example/sinitto/point/entity/PointLogTest.java
@@ -1,0 +1,72 @@
+package com.example.sinitto.point.entity;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.exception.InvalidPointStatusException;
+import com.example.sinitto.point.repository.PointLogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+class PointLogTest {
+
+    @Autowired
+    PointLogRepository pointLogRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(new Member("James", "01099991234", "g@gmail.com", true));
+    }
+
+    @Test
+    @DisplayName("포인트 로그 ChargeWaiting 상태로 전환 성공")
+    void changeStatusToChargeWaiting() {
+        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, PointLog.Status.CHARGE_REQUEST));
+
+        pointLog.changeStatusToChargeWaiting();
+
+        assertEquals(PointLog.Status.CHARGE_WAITING, pointLog.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"EARN", "SPEND_RESERVE", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_WAITING", "CHARGE_COMPLETE"})
+    @DisplayName("포인트 로그 ChargeWaiting 상태로 전환 실패")
+    void changeStatusToChargeWaiting_fail(String initialStatus) {
+        PointLog.Status status = PointLog.Status.valueOf(initialStatus);
+        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, status));
+
+        assertThrows(InvalidPointStatusException.class, pointLog::changeStatusToChargeWaiting);
+    }
+
+    @Test
+    @DisplayName("포인트 로그 ChargeComplete 상태로 전환 성공")
+    void changeStatusToChargeComplete() {
+        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, PointLog.Status.CHARGE_WAITING));
+
+        pointLog.changeStatusToChargeComplete();
+
+        assertEquals(PointLog.Status.CHARGE_COMPLETE, pointLog.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"EARN", "SPEND_RESERVE", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_REQUEST", "CHARGE_COMPLETE"})
+    @DisplayName("포인트 로그 ChargeComplete 상태로 전환 실패")
+    void changeStatusToChargeComplete_fail(String initialStatus) {
+        PointLog.Status status = PointLog.Status.valueOf(initialStatus);
+        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, status));
+
+        assertThrows(InvalidPointStatusException.class, pointLog::changeStatusToChargeComplete);
+    }
+}

--- a/src/test/java/com/example/sinitto/point/entity/PointLogTest.java
+++ b/src/test/java/com/example/sinitto/point/entity/PointLogTest.java
@@ -1,72 +1,167 @@
 package com.example.sinitto.point.entity;
 
 import com.example.sinitto.member.entity.Member;
-import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.exception.InvalidPointLogStatusException;
-import com.example.sinitto.point.repository.PointLogRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DataJpaTest
+
 class PointLogTest {
 
-    @Autowired
-    PointLogRepository pointLogRepository;
-    @Autowired
-    MemberRepository memberRepository;
-
-    Member member;
-
-    @BeforeEach
-    void setUp() {
-        member = memberRepository.save(new Member("James", "01099991234", "g@gmail.com", true));
-    }
+    Member member = new Member("test", "test", "test", true);
 
     @Test
     @DisplayName("포인트 로그 ChargeWaiting 상태로 전환 성공")
     void changeStatusToChargeWaiting() {
-        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, PointLog.Status.CHARGE_REQUEST));
+        //given
+        PointLog pointLog = new PointLog("content", member, 1000, PointLog.Status.CHARGE_REQUEST);
 
+        //when
         pointLog.changeStatusToChargeWaiting();
 
+        //then
         assertEquals(PointLog.Status.CHARGE_WAITING, pointLog.getStatus());
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_WAITING", "CHARGE_COMPLETE"})
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_WAITING", "CHARGE_COMPLETE"})
     @DisplayName("포인트 로그 ChargeWaiting 상태로 전환 실패")
     void changeStatusToChargeWaiting_fail(String initialStatus) {
+        //given
         PointLog.Status status = PointLog.Status.valueOf(initialStatus);
-        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, status));
+        PointLog pointLog = new PointLog("content", member, 1000, status);
 
+        //when then
         assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToChargeWaiting);
     }
 
     @Test
     @DisplayName("포인트 로그 ChargeComplete 상태로 전환 성공")
     void changeStatusToChargeComplete() {
-        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, PointLog.Status.CHARGE_WAITING));
+        //given
+        PointLog pointLog = new PointLog("content", member, 1000, PointLog.Status.CHARGE_WAITING);
 
+        //when
         pointLog.changeStatusToChargeComplete();
 
+        //then
         assertEquals(PointLog.Status.CHARGE_COMPLETE, pointLog.getStatus());
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "REFUND", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_REQUEST", "CHARGE_COMPLETE"})
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "CHARGE_REQUEST", "CHARGE_COMPLETE"})
     @DisplayName("포인트 로그 ChargeComplete 상태로 전환 실패")
     void changeStatusToChargeComplete_fail(String initialStatus) {
+        //given
         PointLog.Status status = PointLog.Status.valueOf(initialStatus);
-        PointLog pointLog = pointLogRepository.save(new PointLog("content", member, 1000, status));
+        PointLog pointLog = new PointLog("content", member, 1000, status);
 
+        //when then
         assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToChargeComplete);
+    }
+
+    @Test
+    @DisplayName("포인트 로그 ChargeFail 상태로 전환 성공")
+    void changeStatusToChargeFail() {
+        //given
+        PointLog pointLog = new PointLog("content", member, 1000, PointLog.Status.CHARGE_WAITING);
+
+        //when
+        pointLog.changeStatusToChargeFail();
+
+        //then
+        assertEquals(PointLog.Status.CHARGE_FAIL, pointLog.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "WITHDRAW_REQUEST", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE","WITHDRAW_FAIL_AND_RESTORE_POINT", "CHARGE_REQUEST", "CHARGE_COMPLETE","CHARGE_FAIL"})
+    @DisplayName("포인트 로그 ChargeFail 상태로 전환 실패")
+    void changeStatusToChargeFail_fail(String initialStatus) {
+        //given
+        PointLog.Status status = PointLog.Status.valueOf(initialStatus);
+        PointLog pointLog = new PointLog("content", member, 1000, status);
+
+        //when then
+        assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToChargeFail);
+    }
+
+    @Test
+    @DisplayName("포인트 로그 WithdrawWaiting 상태로 전환 성공")
+    void changeStatusToWithdrawWaiting() {
+        //given
+        PointLog pointLog = new PointLog("content", member, 1000, PointLog.Status.WITHDRAW_REQUEST);
+
+        //when
+        pointLog.changeStatusToWithdrawWaiting();
+
+        //then
+        assertEquals(PointLog.Status.WITHDRAW_WAITING, pointLog.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "WITHDRAW_WAITING", "WITHDRAW_COMPLETE", "WITHDRAW_FAIL_AND_RESTORE_POINT", "CHARGE_REQUEST", "CHARGE_COMPLETE", "CHARGE_FAIL","CHARGE_WAITING"})
+    @DisplayName("포인트 로그 WithdrawWaiting 상태로 전환 실패")
+    void changeStatusToWithdrawWaiting_fail(String initialStatus) {
+        //given
+        PointLog.Status status = PointLog.Status.valueOf(initialStatus);
+        PointLog pointLog = new PointLog("content", member, 1000, status);
+
+        //when then
+        assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToWithdrawWaiting);
+    }
+
+    @Test
+    @DisplayName("포인트 로그 WithdrawComplete 상태로 전환 성공")
+    void changeStatusToWithdrawComplete() {
+        //given
+        PointLog pointLog = new PointLog("content", member, 1000, PointLog.Status.WITHDRAW_WAITING);
+
+        //when
+        pointLog.changeStatusToWithdrawComplete();
+
+        //then
+        assertEquals(PointLog.Status.WITHDRAW_COMPLETE, pointLog.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "WITHDRAW_REQUEST", "WITHDRAW_COMPLETE", "WITHDRAW_FAIL_AND_RESTORE_POINT", "CHARGE_REQUEST", "CHARGE_COMPLETE", "CHARGE_FAIL"})
+    @DisplayName("포인트 로그 WithdrawComplete 상태로 전환 실패")
+    void changeStatusToWithdrawComplete_fail(String initialStatus) {
+        //given
+        PointLog.Status status = PointLog.Status.valueOf(initialStatus);
+        PointLog pointLog = new PointLog("content", member, 1000, status);
+
+        //when then
+        assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToWithdrawComplete);
+    }
+
+    @Test
+    @DisplayName("포인트 로그 WithdrawFail 상태로 전환 성공")
+    void changeStatusToWithdrawFail() {
+        //given
+        PointLog pointLog = new PointLog("content", member, 1000, PointLog.Status.WITHDRAW_WAITING);
+
+        //when
+        pointLog.changeStatusToWithdrawFail();
+
+        //then
+        assertEquals(PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT, pointLog.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"EARN", "SPEND_COMPLETE", "SPEND_CANCEL", "WITHDRAW_REQUEST", "WITHDRAW_COMPLETE", "WITHDRAW_FAIL_AND_RESTORE_POINT", "CHARGE_REQUEST", "CHARGE_COMPLETE", "CHARGE_FAIL"})
+    @DisplayName("포인트 로그 WithdrawFail 상태로 전환 실패")
+    void changeStatusToWithdrawFail_fail(String initialStatus) {
+        //given
+        PointLog.Status status = PointLog.Status.valueOf(initialStatus);
+        PointLog pointLog = new PointLog("content", member, 1000, status);
+
+        //when then
+        assertThrows(InvalidPointLogStatusException.class, pointLog::changeStatusToWithdrawFail);
     }
 }

--- a/src/test/java/com/example/sinitto/point/entity/PointTest.java
+++ b/src/test/java/com/example/sinitto/point/entity/PointTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.junit.jupiter.MockitoSettings;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 @MockitoSettings
@@ -23,5 +23,41 @@ class PointTest {
 
         //then
         assertEquals(3100, point.getPrice());
+    }
+
+    @Test
+    @DisplayName("포인트 차감")
+    void deduct() {
+        //given
+        Member member = mock(Member.class);
+        Point point = new Point(100, member);
+
+        //when
+        point.deduct(80);
+
+        //then
+        assertEquals(20, point.getPrice());
+    }
+
+    @Test
+    @DisplayName("차감이 되는지 확인 - FALSE")
+    void isSufficientForDeduction() {
+        //given
+        Member member = mock(Member.class);
+        Point point = new Point(100, member);
+
+        //when then
+        assertFalse(point.isSufficientForDeduction(3000));
+    }
+
+    @Test
+    @DisplayName("차감이 되는지 확인 - TRUE")
+    void isSufficientForDeduction2() {
+        //given
+        Member member = mock(Member.class);
+        Point point = new Point(5000, member);
+
+        //when then
+        assertTrue(point.isSufficientForDeduction(3000));
     }
 }

--- a/src/test/java/com/example/sinitto/point/entity/PointTest.java
+++ b/src/test/java/com/example/sinitto/point/entity/PointTest.java
@@ -1,0 +1,27 @@
+package com.example.sinitto.point.entity;
+
+import com.example.sinitto.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@MockitoSettings
+class PointTest {
+
+    @Test
+    @DisplayName("포인트 적립")
+    void earn() {
+        //given
+        Member member = mock(Member.class);
+        Point point = new Point(100, member);
+
+        //when
+        point.earn(3000);
+
+        //then
+        assertEquals(3100, point.getPrice());
+    }
+}

--- a/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
+++ b/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
@@ -5,7 +5,6 @@ import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointLogResponse;
 import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.repository.PointLogRepository;
-import com.example.sinitto.point.repository.PointRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -28,8 +27,6 @@ class PointServiceTest {
 
     @Mock
     MemberRepository memberRepository;
-    @Mock
-    PointRepository pointRepository;
     @Mock
     PointLogRepository pointLogRepository;
     @InjectMocks
@@ -58,6 +55,6 @@ class PointServiceTest {
         //then
         assertNotNull(result);
         assertEquals(1, result.getTotalElements());
-        assertEquals(PointLog.Status.EARN, result.getContent().get(0).status());
+        assertEquals(PointLog.Status.EARN, result.getContent().getFirst().status());
     }
 }

--- a/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
+++ b/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.sinitto.point.service;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointLogResponse;
+import com.example.sinitto.point.entity.PointLog;
+import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings
+class PointServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    PointRepository pointRepository;
+    @Mock
+    PointLogRepository pointLogRepository;
+    @InjectMocks
+    PointService pointService;
+
+    @Test
+    void getPointLogs() {
+        //given
+        Long memberId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Member member = mock(Member.class);
+        PointLog pointLog = mock(PointLog.class);
+
+        when(pointLog.getContent()).thenReturn("content");
+        when(pointLog.getPrice()).thenReturn(10000);
+        when(pointLog.getStatus()).thenReturn(PointLog.Status.EARN);
+
+        Page<PointLog> pointLogPage = new PageImpl<>(List.of(pointLog));
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(pointLogRepository.findAllByMember(member, pageable)).thenReturn(pointLogPage);
+
+        //when
+        Page<PointLogResponse> result = pointService.getPointLogs(memberId, pageable);
+
+        //then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals(PointLog.Status.EARN, result.getContent().get(0).status());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#45 


## 📝 작업 내용
### 출금, 충전 관련 이런 방식 채택한 나름의 이유
- 은행관련 API 사용에 제한사항이 많으니 어떻게든 현실성 있는 방식으로 포인트 충전, 출금을 구현하고자 노력
- 충전, 출금에 관해서 현 시점에서 가장 현실성 있는 방식이라고 일단 판단하고 일단은 구현했습니다.
- 결제 시스템 수수료 없음
- 사업자 번호 필요 없음
### 수수료
- 출금 요청 시, 임시로 출금 요청 금액의 20%는 수수료로 책정 하였습니다. 시니또는 본인의 출금 요청 금액에서 80%만 가져갑니다.
### 보안 관련
- 먼저 포인트 서비스 로직부터 리뷰를 받고 어느정도 완성이 된 이후에 보안관련해서 개선을 진행해 보겠습니다.
- POSTMAN같은 경우 CORS 정책이 브라우저를 위한 정책이기 때문에 브라우저가 아닌 POSTMAN은 CORS 설정에서 자유로웠던걸로 파악됩니다. 그나마 쉽게 POSTMAN을 막는것은 특정 IP 요청에만 응답을 해주거나 하는 방법이 있는건 확인했지만, 얕게 찾아봐서 확신은 없는 상황입니다. 좀더 공부해 보겠습니다.
- HMAC 는 REQUEST의 위변조를 검사해주는 방법중 하나인것으로 보입니다. 이것도 더 공부해보겠습니다.
### 포인트 로그 상태 설명
- 적립(EARN)
    - 보호자가 콜백이나 안부전화 완료 확정 or 완료 상태가 지속될시 특정 기간이후 -> 시니또에게 포인트가 적립 && 로그 생성
    - 포인트 증가
- 소비 완료(SPEND_COMPLETE)
    - 콜백이나 안부전화 서비스 요청이 DB에 추가되는 순간 로그 생성
    - 포인트 감소
- 소비 취소(SPEND_CANCEL)
    - 신청된 서비스를 시니또가 수락 전에 보호자가 취소하는 순간 로그 생성
    - 포인트 증가
> 충전 파트는 관리자가 관리

>충전은 한 로그에서 상태 변화하는 방식임
- 충전 신청(CHARGE_REQUEST)
    -  멤버가 포인트 요청햇을때 상태
    - 이름(3자) + 번호(전화번호 뒷 4자)를 `depositMessage` 라는 응답으로 줍니다. 충전하려는 사람은 우리 계좌에 입금시 저 메시지를 기입해야 합니다.
- 충전 대기(CHARGE_WAITNG)
    -  관리자가 관리자 페이지에서 보고 대기상태로 전환 시켰을때 상태.
    - 유저에게 관리자가 봤다는 피드백을 주는 것.
- 충전 완료(CHARGE_COMPLETE)
    -  관리자가 우리 계좌에 요청한 금액이 입금되었는지와 입금 메시지를 확인하고 맞다면 `포인트 지급 & 완료 상태로 변경` 버튼 누릅니다.
    -  **이 상태로 전환되면서 동시에 포인트 충전이 된다**
- 충전 실패(CHARGE_FAIL)
    -  모종의 이유로 관리자가 실패 상태로 전환 시킴
    
> 출금 파트는 관리자가 관리

> 출금은 한 로그에서 상태 변화하는 방식임

- 출금 신청(WITHDRAW_REQUEST)
    - 멤버가 포인트 요청햇을때 상태
    - 포인트 감소
- 출금 대기(WITHDRAW_WAITING)
    - 관리자가 관리자 페이지에서 보고 대기상태로 전환 시켰을때 상태.
    - 유저에게 관리자가 봤다는 피드백을 주는 것.
- 출금 완료(WITHDRAW_COMPLETE)
    - 관리자가 출금 관리자 페이지에서 시니또의 계좌번호, 은행명을 보고서 입금을 해준다.
    - 입금후 완료 상태로 변경
- 출금 실패(WITHDRAW_FAIL_AND_RESTORE_POINT)
    - 모종의 이유로 관리자가 실패 상태로 전환 시킴
    - 출금 신청 상태로 변할 때 감소한 포인트를 원상복구 시킨다

## 스크린샷
### 포인트 충전 관리자 페이지(`/admin/point/charge`)
![SCR-20241012-bznx](https://github.com/user-attachments/assets/ff0bf305-53f2-4764-9c34-28d8844bcd61)
![SCR-20241012-bzqy](https://github.com/user-attachments/assets/93d7d69c-3448-4f49-816b-6b3e8d2d60d6)
![SCR-20241012-bzsq](https://github.com/user-attachments/assets/92631cf7-83d5-4d35-9ba1-eedb981182a4)

### 포인트 출금 관리자 페이지(`/admin/point/withdraw`)
5000원 출금 요청... 20%수수료 떼인상황

![SCR-20241012-caab](https://github.com/user-attachments/assets/a3179ecf-d9c7-4144-b3bb-76f9edeba486)
![SCR-20241012-cadd](https://github.com/user-attachments/assets/887f5c53-2ceb-4727-9661-0700bb98e8b7)
![SCR-20241012-cael](https://github.com/user-attachments/assets/463c2fb5-59a3-4b99-ac21-5c5e7557d1bb)




## 💬 리뷰 요구사항(선택)

- 깔끔히 설명드리고 싶은데 설명이 잘 되었는지 확신이 안드네요. 뭐든 리뷰하며 이해안되거나 이상한거 찝어주시면 감사하겠습니다.
- 개선할 사항 편히 말씀 해주세욤

## 참고
- https://www.notion.so/API-a81d4bcd1ee443fd839f7003edb2c1f6?pvs=4 (간단한 플로우들... 더 추가해보려 노력)
## ⏰ 현재 버그


## ✏ Git Close


close #45 
