### PR TITLE
Refactor: 3차 리뷰 수정사항 적용 구현 (안부전화, 카카오API 관련)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation group: 'com.twilio.sdk', name: 'twilio', version: '10.5.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/sinitto/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/example/sinitto/auth/dto/KakaoTokenResponse.java
@@ -3,12 +3,15 @@ package com.example.sinitto.auth.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoTokenResponse(
         String accessToken,
         String refreshToken,
+        @NotNull
         int expiresIn,
+        @NotNull
         int refreshTokenExpiresIn
 
 ) {

--- a/src/main/java/com/example/sinitto/common/config/WebConfig.java
+++ b/src/main/java/com/example/sinitto/common/config/WebConfig.java
@@ -1,8 +1,14 @@
 package com.example.sinitto.common.config;
 
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -15,14 +21,32 @@ import java.time.Duration;
 public class WebConfig implements WebMvcConfigurer {
 
     private static final int TIME_OUT_DURATION = 5;
+    private static final int MAX_OPEN_CONNECTIONS = 100;
+    private static final int CONNECTIONS_PER_IP_PORT_PAIR = 5;
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder, RestTemplateResponseErrorHandler errorHandler) {
         return builder
                 .errorHandler(errorHandler)
-                .setConnectTimeout(Duration.ofSeconds(TIME_OUT_DURATION))
-                .setReadTimeout(Duration.ofSeconds(TIME_OUT_DURATION))
+                .requestFactory(this::httpComponentsClientHttpRequestFactory)
                 .build();
+    }
+
+    private HttpComponentsClientHttpRequestFactory httpComponentsClientHttpRequestFactory() {
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(MAX_OPEN_CONNECTIONS);
+        connectionManager.setDefaultMaxPerRoute(CONNECTIONS_PER_IP_PORT_PAIR);
+
+        CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setResponseTimeout(Timeout.of(Duration.ofSeconds(TIME_OUT_DURATION)))
+                        .setConnectTimeout(Timeout.of(Duration.ofSeconds(TIME_OUT_DURATION)))
+                        .setConnectionRequestTimeout(Timeout.of(Duration.ofSeconds(TIME_OUT_DURATION)))
+                        .build())
+                .build();
+
+        return new HttpComponentsClientHttpRequestFactory(httpClient);
     }
 
     @Bean

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailResponse.java
@@ -17,9 +17,9 @@ public record HelloCallDetailResponse(
 ) {
     public record TimeSlot(
             String dayName,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime startTime,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallDetailUpdateRequest.java
@@ -16,9 +16,9 @@ public record HelloCallDetailUpdateRequest(
 ) {
     public record TimeSlot(
             String dayName,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime startTime,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallPriceRequest.java
@@ -14,9 +14,9 @@ public record HelloCallPriceRequest(
 ) {
     public record TimeSlot(
             String dayName,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime startTime,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
+++ b/src/main/java/com/example/sinitto/helloCall/dto/HelloCallRequest.java
@@ -17,9 +17,9 @@ public record HelloCallRequest(
 ) {
     public record TimeSlot(
             String dayName,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime startTime,
-            @JsonFormat(pattern = "kk:mm")
+            @JsonFormat(pattern = "HH:mm")
             LocalTime endTime) {
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -131,7 +131,7 @@ public class HelloCall {
     }
 
     public void checkStatusIsWaiting() {
-        if (!this.status.equals(Status.WAITING)) {
+        if (status.canNotModifyOrDelete()) {
             throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 삭제가 가능합니다.");
         }
     }
@@ -157,35 +157,35 @@ public class HelloCall {
     }
 
     public void changeStatusToInProgress() {
-        if (!this.status.equals(Status.WAITING)) {
-            throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
+        if (status.canNotProgressStatus(Status.IN_PROGRESS)) {
+            throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 진행중 상태로 나아갈 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.IN_PROGRESS;
     }
 
     public void changeStatusToWaiting() {
-        if (!this.status.equals(Status.IN_PROGRESS)) {
-            throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
+        if (status.canNotRollBackStatus()) {
+            throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 진행중 상태로 돌아갈 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.WAITING;
     }
 
     public void changeStatusToPendingComplete() {
-        if (!this.status.equals(Status.IN_PROGRESS)) {
-            throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 완료 대기 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
+        if (status.canNotProgressStatus(Status.PENDING_COMPLETE)) {
+            throw new InvalidStatusException("안부전화 서비스가 수행중일 때만 완료 대기 상태로 나아갈 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.PENDING_COMPLETE;
     }
 
     public void changeStatusToComplete() {
-        if (!this.status.equals(Status.PENDING_COMPLETE)) {
+        if (status.canNotProgressStatus(Status.COMPLETE)) {
             throw new InvalidStatusException("안부전화 서비스가 완료 대기 일때만 완료 상태로 변경할 수 있습니다. 현재 상태 : " + this.status);
         }
         this.status = Status.COMPLETE;
     }
 
     public void updateHelloCall(LocalDate startDate, LocalDate endDate, int price, int serviceTime, String requirement) {
-        if (!this.status.equals(Status.WAITING)) {
+        if (status.canNotModifyOrDelete()) {
             throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 수정이 가능합니다.");
         }
         if (startDate.isAfter(endDate)) {
@@ -202,6 +202,23 @@ public class HelloCall {
         WAITING,
         IN_PROGRESS,
         PENDING_COMPLETE,
-        COMPLETE
+        COMPLETE;
+
+        public boolean canNotProgressStatus(Status newStatus) {
+            return !switch (this) {
+                case WAITING -> newStatus.equals(IN_PROGRESS);
+                case IN_PROGRESS -> newStatus.equals(PENDING_COMPLETE);
+                case PENDING_COMPLETE -> newStatus.equals(COMPLETE);
+                default -> false;
+            };
+        }
+
+        public boolean canNotRollBackStatus() {
+            return !this.equals(IN_PROGRESS);
+        }
+
+        public boolean canNotModifyOrDelete() {
+            return !this.equals(WAITING);
+        }
     }
 }

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -126,10 +126,6 @@ public class HelloCall {
         return helloCallTimeLogs;
     }
 
-    public boolean checkUnAuthorization(Member member) {
-        return !this.senior.getMember().equals(member);
-    }
-
     public void checkStatusIsWaiting() {
         if (status.canNotModifyOrDelete()) {
             throw new InvalidStatusException("안부전화 서비스가 수행 대기중일 때만 삭제가 가능합니다.");
@@ -144,7 +140,7 @@ public class HelloCall {
 
     public void checkGuardIsCorrect(Member member) {
         if (!this.senior.getMember().equals(member)) {
-            throw new UnauthorizedException("해당 시니어의 안부전화를 신청한 보호자가 아닙니다.");
+            throw new UnauthorizedException("해당 시니어의 안부전화를 신청한 보호자가 아닙니다. 권한이 없습니다.");
         }
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallTimeLogRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface HelloCallTimeLogRepository extends JpaRepository<HelloCallTimeLog, Long> {
-    Optional<HelloCallTimeLog> findBySinittoAndAndHelloCallId(Sinitto sinitto, Long helloCallId);
+    Optional<HelloCallTimeLog> findBySinittoAndHelloCallId(Sinitto sinitto, Long helloCallId);
 
     List<HelloCallTimeLog> findAllByHelloCallId(Long helloCallId);
 

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -159,9 +159,7 @@ public class HelloCallService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다."));
 
-        if (helloCall.checkUnAuthorization(member)) {
-            throw new UnauthorizedException("안부전화 정보를 수정할 권한이 없습니다.");
-        }
+        helloCall.checkGuardIsCorrect(member);
 
         helloCall.updateHelloCall(helloCallDetailUpdateRequest.startDate(), helloCallDetailUpdateRequest.endDate(),
                 helloCallDetailUpdateRequest.price(), helloCallDetailUpdateRequest.serviceTime(), helloCallDetailUpdateRequest.requirement());
@@ -188,9 +186,7 @@ public class HelloCallService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다."));
 
-        if (helloCall.checkUnAuthorization(member)) {
-            throw new UnauthorizedException("안부전화 신청을 취소할 권한이 없습니다.");
-        }
+        helloCall.checkGuardIsCorrect(member);
 
         Point point = pointRepository.findByMemberIdWithWriteLock(memberId)
                 .orElseThrow(() -> new PointNotFoundException("멤버에 연관된 포인트가 없습니다."));
@@ -217,9 +213,7 @@ public class HelloCallService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("id에 해당하는 멤버를 찾을 수 없습니다."));
 
-        if (helloCall.checkUnAuthorization(member)) {
-            throw new UnauthorizedException("안부전화 로그를 조회할 권한이 없습니다.");
-        }
+        helloCall.checkGuardIsCorrect(member);
 
         List<HelloCallTimeLog> helloCallTimeLogs = helloCallTimeLogRepository.findAllByHelloCallId(helloCallId);
 

--- a/src/test/java/com/example/sinitto/hellocall/entity/HelloCallTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/entity/HelloCallTest.java
@@ -80,13 +80,13 @@ class HelloCallTest {
 
         assertThatThrownBy(() -> helloCall.changeStatusToInProgress())
                 .isInstanceOf(InvalidStatusException.class)
-                .hasMessage("안부전화 서비스가 수행 대기중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + HelloCall.Status.IN_PROGRESS);
+                .hasMessage("안부전화 서비스가 수행 대기중일 때만 진행중 상태로 나아갈 수 있습니다. 현재 상태 : " + HelloCall.Status.IN_PROGRESS);
 
         helloCall.changeStatusToPendingComplete();
 
         assertThatThrownBy(() -> helloCall.changeStatusToWaiting())
                 .isInstanceOf(InvalidStatusException.class)
-                .hasMessage("안부전화 서비스가 수행중일 때만 진행중 상태로 변경할 수 있습니다. 현재 상태 : " + HelloCall.Status.PENDING_COMPLETE);
+                .hasMessage("안부전화 서비스가 수행중일 때만 진행중 상태로 돌아갈 수 있습니다. 현재 상태 : " + HelloCall.Status.PENDING_COMPLETE);
     }
 
     @Test

--- a/src/test/java/com/example/sinitto/hellocall/repository/HelloCallTimeLogRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/repository/HelloCallTimeLogRepositoryTest.java
@@ -71,7 +71,7 @@ class HelloCallTimeLogRepositoryTest {
         HelloCallTimeLog timeLog = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.of(2024, 1, 1, 10, 0), LocalDateTime.of(2024, 1, 1, 11, 0));
         helloCallTimeLogRepository.save(timeLog);
 
-        Optional<HelloCallTimeLog> foundTimeLog = helloCallTimeLogRepository.findBySinittoAndAndHelloCallId(sinitto, helloCall.getId());
+        Optional<HelloCallTimeLog> foundTimeLog = helloCallTimeLogRepository.findBySinittoAndHelloCallId(sinitto, helloCall.getId());
 
         assertThat(foundTimeLog).isPresent();
         assertThat(foundTimeLog.get().getHelloCall()).isEqualTo(helloCall);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #70 

## 📝 작업 내용
- 상태 조건문 검증 메서드 분리
- 중복된 메서드 통일
- 카카오토큰 int형 필드에 notnull추가
- JsonFormat kk:mm -> HH:mm으로 변경
- restTemplate connection pool 설정

## 💬 리뷰 요구사항(선택)
- Connection Pool을 사용하는 이유
https://thenicesj.tistory.com/921 참고하시면 좋을 것 같습니다.
구체적 구현은 버전이 달라서 다릅니다.
현재는 요청이 많지 않기 때문에 최대 커넥션수는 100개, 라우트당 커넥션 수는 5개로 설정하였습니다.

## ⏰ 현재 버그
리팩토링 후 테스트코드 구동 결과 이상 없습니다.

## ✏ Git Close
close #70 