### PR TITLE
Feat: 이미 진행중 or 대기중 인 콜백이 있으면 추가적인 콜백 생성 안되게 함

### DIFF
--- a/src/main/java/com/example/sinitto/callback/controller/CallbackController.java
+++ b/src/main/java/com/example/sinitto/callback/controller/CallbackController.java
@@ -37,7 +37,7 @@ public class CallbackController {
     public ResponseEntity<Void> pendingCompleteCallback(@MemberId Long memberId,
                                                         @PathVariable Long callbackId) {
 
-        callbackService.pendingComplete(memberId, callbackId);
+        callbackService.changeCallbackStatusToPendingCompleteBySinitto(memberId, callbackId);
         return ResponseEntity.ok().build();
     }
 
@@ -55,7 +55,7 @@ public class CallbackController {
     public ResponseEntity<Void> acceptCallback(@MemberId Long memberId,
                                                @PathVariable Long callbackId) {
 
-        callbackService.accept(memberId, callbackId);
+        callbackService.acceptCallbackBySinitto(memberId, callbackId);
         return ResponseEntity.ok().build();
     }
 
@@ -64,14 +64,14 @@ public class CallbackController {
     public ResponseEntity<Void> cancelCallback(@MemberId Long memberId,
                                                @PathVariable Long callbackId) {
 
-        callbackService.cancel(memberId, callbackId);
+        callbackService.cancelCallbackAssignmentBySinitto(memberId, callbackId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/twilio")
     public ResponseEntity<String> addCallCheck(@RequestParam("From") String fromNumber) {
 
-        return ResponseEntity.ok(callbackService.add(fromNumber));
+        return ResponseEntity.ok(callbackService.createCallbackByCall(fromNumber));
     }
 
     @Operation(summary = "시니또에게 현재 할당된 콜백 조회", description = "현재 시니또 본인에게 할당된 콜백을 조회합니다.")

--- a/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
+++ b/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
@@ -21,4 +21,6 @@ public interface CallbackRepository extends JpaRepository<Callback, Long> {
     Page<Callback> findAllBySeniorIn(List<Senior> seniors, Pageable pageable);
 
     List<Callback> findAllByStatusAndPendingCompleteTimeBefore(Callback.Status status, LocalDateTime dateTime);
+
+    boolean existsBySeniorAndStatusIn(Senior senior, List<Callback.Status> statuses);
 }

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -32,7 +32,7 @@ public class CallbackService {
     private static final String SUCCESS_MESSAGE = "감사합니다. 잠시만 기다려주세요.";
     private static final String FAIL_MESSAGE_NOT_ENROLLED = "등록된 사용자가 아닙니다. 서비스 이용이 불가합니다.";
     private static final String FAIL_MESSAGE_NOT_ENOUGH_POINT = "포인트가 부족합니다. 서비스 이용이 불가합니다.";
-    private static final String FAIL_MESSAGE_ALREADY_HAS_CALLBACK_IN_PROGRESS_OR_WAITING = "이미 대기중이거나 진행중인 콜백이 있습니다. 그러므로 추가 요청이 불가합니다.";
+    private static final String FAIL_MESSAGE_ALREADY_HAS_CALLBACK_IN_PROGRESS_OR_WAITING = "어르신의 요청이 이미 접수되었습니다. 잠시 기다려주시면 연락드리겠습니다.";
     private final CallbackRepository callbackRepository;
     private final MemberRepository memberRepository;
     private final SeniorRepository seniorRepository;

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -32,6 +32,7 @@ public class CallbackService {
     private static final String SUCCESS_MESSAGE = "감사합니다. 잠시만 기다려주세요.";
     private static final String FAIL_MESSAGE_NOT_ENROLLED = "등록된 사용자가 아닙니다. 서비스 이용이 불가합니다.";
     private static final String FAIL_MESSAGE_NOT_ENOUGH_POINT = "포인트가 부족합니다. 서비스 이용이 불가합니다.";
+    private static final String FAIL_MESSAGE_ALREADY_HAS_CALLBACK_IN_PROGRESS_OR_WAITING = "이미 대기중이거나 진행중인 콜백이 있습니다. 그러므로 추가 요청이 불가합니다.";
     private final CallbackRepository callbackRepository;
     private final MemberRepository memberRepository;
     private final SeniorRepository seniorRepository;
@@ -56,7 +57,7 @@ public class CallbackService {
     }
 
     @Transactional
-    public void accept(Long memberId, Long callbackId) {
+    public void acceptCallbackBySinitto(Long memberId, Long callbackId) {
 
         checkAuthorization(memberId);
 
@@ -71,7 +72,7 @@ public class CallbackService {
     }
 
     @Transactional
-    public void pendingComplete(Long memberId, Long callbackId) {
+    public void changeCallbackStatusToPendingCompleteBySinitto(Long memberId, Long callbackId) {
 
         checkAuthorization(memberId);
 
@@ -125,7 +126,7 @@ public class CallbackService {
     }
 
     @Transactional
-    public void cancel(Long memberId, Long callbackId) {
+    public void cancelCallbackAssignmentBySinitto(Long memberId, Long callbackId) {
 
         checkAuthorization(memberId);
 
@@ -138,7 +139,7 @@ public class CallbackService {
     }
 
     @Transactional
-    public String add(String fromNumber) {
+    public String createCallbackByCall(String fromNumber) {
 
         String phoneNumber = TwilioHelper.trimPhoneNumber(fromNumber);
 
@@ -150,6 +151,10 @@ public class CallbackService {
         Point point = findPointWithWriteLock(senior.getMember().getId());
         if (point == null || !point.isSufficientForDeduction(CALLBACK_PRICE)) {
             return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_NOT_ENOUGH_POINT);
+        }
+
+        if (callbackRepository.existsBySeniorAndStatusIn(senior, List.of(Callback.Status.WAITING, Callback.Status.IN_PROGRESS))) {
+            return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_ALREADY_HAS_CALLBACK_IN_PROGRESS_OR_WAITING);
         }
 
         point.deduct(CALLBACK_PRICE);

--- a/src/main/resources/templates/point/withdraw.html
+++ b/src/main/resources/templates/point/withdraw.html
@@ -43,7 +43,7 @@
 
                 <!-- 상태가 CHARGE_WAITING일 때 -->
                 <form method="post"
-                      th:action="@{/admin/point/charge/fail/{pointLogId}(pointLogId=${logWithBankInfo.pointLogId})}"
+                      th:action="@{/admin/point/withdraw/fail/{pointLogId}(pointLogId=${logWithBankInfo.pointLogId})}"
                       th:if="${logWithBankInfo.status.toString()} == 'WITHDRAW_WAITING'">
                     <button type="submit">실패 상태로 변경</button>
                 </form>

--- a/src/test/java/com/example/sinitto/callback/repository/CallbackRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/callback/repository/CallbackRepositoryTest.java
@@ -220,4 +220,27 @@ class CallbackRepositoryTest {
         assertEquals(0, result.size());
 
     }
+
+    @Test
+    @DisplayName("시니어와 상태들을 조건을 활용한 조회 테스트")
+    void existsBySeniorAndStatusIn() {
+        // given
+        Senior testSenior = seniorRepository.save(new Senior("senior", "01012341234", testMember));
+
+        callbackRepository.save(new Callback(Callback.Status.WAITING, testSenior));
+        callbackRepository.save(new Callback(Callback.Status.PENDING_COMPLETE, testSenior));
+        callbackRepository.save(new Callback(Callback.Status.COMPLETE, testSenior));
+
+        // when
+        boolean result1 = callbackRepository.existsBySeniorAndStatusIn(testSenior, List.of(Callback.Status.IN_PROGRESS, Callback.Status.WAITING));
+        boolean result2 = callbackRepository.existsBySeniorAndStatusIn(testSenior, List.of(Callback.Status.WAITING));
+        boolean result3 = callbackRepository.existsBySeniorAndStatusIn(testSenior, List.of(Callback.Status.IN_PROGRESS));
+        boolean result4 = callbackRepository.existsBySeniorAndStatusIn(testSenior, List.of(Callback.Status.COMPLETE));
+
+        // then
+        assertTrue(result1);
+        assertTrue(result2);
+        assertFalse(result3);
+        assertTrue(result4);
+    }
 }

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -107,7 +107,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("콜백 수락 - 성공")
-    void accept() {
+    void acceptCallbackBySinitto() {
         //given
         Long memberId = 1L;
         Long callbackId = 1L;
@@ -120,7 +120,7 @@ class CallbackServiceTest {
         when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
 
         //when
-        callbackService.accept(memberId, callbackId);
+        callbackService.acceptCallbackBySinitto(memberId, callbackId);
 
         //then
         verify(callback).assignMember(memberId);
@@ -144,7 +144,7 @@ class CallbackServiceTest {
         when(callback.getAssignedMemberId()).thenReturn(assignedMemberId);
 
         //when
-        callbackService.pendingComplete(memberId, callbackId);
+        callbackService.changeCallbackStatusToPendingCompleteBySinitto(memberId, callbackId);
 
         //then
         verify(callback).changeStatusToPendingComplete();
@@ -152,7 +152,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("수락한 콜백 취소 - 성공")
-    void cancel() {
+    void cancelCallbackAssignmentBySinitto() {
         //given
         Long memberId = 1L;
         Long callbackId = 1L;
@@ -166,7 +166,7 @@ class CallbackServiceTest {
         when(callback.getAssignedMemberId()).thenReturn(1L);
 
         //when
-        callbackService.cancel(memberId, callbackId);
+        callbackService.cancelCallbackAssignmentBySinitto(memberId, callbackId);
 
         //then
         verify(callback).cancelAssignment();
@@ -175,7 +175,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("새로운 콜백 등록")
-    void addCallback() {
+    void createCallbackByCall() {
         //given
         String fromPhoneNumber = "+821012341234";
         String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
@@ -189,7 +189,7 @@ class CallbackServiceTest {
         when(pointRepository.findByMemberIdWithWriteLock(1L)).thenReturn(Optional.of(point));
         when(point.isSufficientForDeduction(anyInt())).thenReturn(true);
         //when
-        String result = callbackService.add(fromPhoneNumber);
+        String result = callbackService.createCallbackByCall(fromPhoneNumber);
 
         //then
         verify(pointLogRepository, times(1)).save(any());
@@ -199,7 +199,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("새로운 콜백 등록할 때 전화온 번호가 등록된 번호가 아닐 때")
-    void addCallback_fail() {
+    void createCallbackByCallingCallback_fail() {
         //given
         String fromPhoneNumber = "+821012341234";
         String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
@@ -207,10 +207,61 @@ class CallbackServiceTest {
         when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.empty());
 
         //when
-        String result = callbackService.add(fromPhoneNumber);
+        String result = callbackService.createCallbackByCall(fromPhoneNumber);
 
         //then
-        verify(callbackRepository, times(0)).save(any());
+        verify(callbackRepository, never()).save(any());
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("새로운 콜백 등록할 때 포인트가 부족할 때")
+    void createCallbackByCallingCallback_fail1() {
+        //given
+        String fromPhoneNumber = "+821012341234";
+        String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
+        Member member = mock(Member.class);
+        Senior senior = mock(Senior.class);
+        Point point = mock(Point.class);
+
+        when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
+        when(senior.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(pointRepository.findByMemberIdWithWriteLock(any(Long.class))).thenReturn(Optional.of(point));
+        when(point.isSufficientForDeduction(anyInt())).thenReturn(false);
+
+        //when
+        String result = callbackService.createCallbackByCall(fromPhoneNumber);
+
+        //then
+        verify(point, never()).deduct(anyInt());
+        verify(callbackRepository, never()).save(any());
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("새로운 콜백 등록할 때 이미 시니어가 신청한 진행중 or 대기중인 콜백이 존재할때")
+    void createCallbackByCallingCallback_fail2() {
+        //given
+        String fromPhoneNumber = "+821012341234";
+        String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
+        Member member = mock(Member.class);
+        Senior senior = mock(Senior.class);
+        Point point = mock(Point.class);
+
+        when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
+        when(senior.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(pointRepository.findByMemberIdWithWriteLock(any(Long.class))).thenReturn(Optional.of(point));
+        when(point.isSufficientForDeduction(anyInt())).thenReturn(true);
+        when(callbackRepository.existsBySeniorAndStatusIn(any(), any())).thenReturn(true);
+
+        //when
+        String result = callbackService.createCallbackByCall(fromPhoneNumber);
+
+        //then
+        verify(point, never()).deduct(anyInt());
+        verify(callbackRepository, never()).save(any());
         assertNotNull(result);
     }
 
@@ -296,7 +347,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("일정 기간동안 PendingComplete 인 콜백 자동으로 Complete 로 전환  - 성공")
-    void changeOldPendingCompleteToCompleteByPolicy_Success() {
+    void changeOldChangeCallbackStatusToPendingCompleteToCompleteBySinittoByPolicy_Success() {
         // Given
         Callback callback1 = mock(Callback.class);
         Point point = mock(Point.class);
@@ -318,7 +369,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("일정 기간동안 PendingComplete 인 콜백 자동으로 Complete 로 전환  - 조건에 맞는 콜백 없을 때")
-    void changeOldPendingCompleteToCompleteByPolicy_Success_zeroList() {
+    void changeOldChangeCallbackStatusToPendingCompleteToCompleteBySinittoByPolicy_Success_zeroList() {
         // Given
         when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
                 .thenReturn(List.of());
@@ -327,7 +378,7 @@ class CallbackServiceTest {
         callbackService.changeOldPendingCompleteToCompleteByPolicy();
 
         // Then
-        verify(pointLogRepository, times(0)).save(any(PointLog.class));
+        verify(pointLogRepository, never()).save(any(PointLog.class));
     }
 
     @Test

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -347,7 +347,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("일정 기간동안 PendingComplete 인 콜백 자동으로 Complete 로 전환  - 성공")
-    void changeOldChangeCallbackStatusToPendingCompleteToCompleteBySinittoByPolicy_Success() {
+    void changeOldPendingCompleteToCompleteByPolicy_Success() {
         // Given
         Callback callback1 = mock(Callback.class);
         Point point = mock(Point.class);
@@ -369,7 +369,7 @@ class CallbackServiceTest {
 
     @Test
     @DisplayName("일정 기간동안 PendingComplete 인 콜백 자동으로 Complete 로 전환  - 조건에 맞는 콜백 없을 때")
-    void changeOldChangeCallbackStatusToPendingCompleteToCompleteBySinittoByPolicy_Success_zeroList() {
+    void changeOldPendingCompleteToCompleteByPolicy_Success_zeroList() {
         // Given
         when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
                 .thenReturn(List.of());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#72 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 메서드 명 좀더 자세하게 수정해보았습니다.
- 시니어가 전화 걸었을때 진행중 or 대기중 인 콜백이 있으면 추가적인 콜백 생성 안되고, 안된다는 메시지 전달합니다.
- 테스트를 조금더 보완하였습니다.

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #72 
