### PR TITLE
Fix: 출금 관리자 페이지 Whitelabel Error Page 발생 버그 수정

### DIFF
--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -1,15 +1,12 @@
 package com.example.sinitto.point.controller;
 
 import com.example.sinitto.member.entity.Member;
-import com.example.sinitto.member.entity.Sinitto;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointLogWithBankInfo;
 import com.example.sinitto.point.dto.PointLogWithDepositMessage;
 import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.service.PointAdminService;
-import com.example.sinitto.sinitto.exception.SinittoNotFoundException;
-import com.example.sinitto.sinitto.repository.SinittoRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,12 +21,10 @@ public class PointAdminController {
 
     private final PointAdminService pointAdminService;
     private final MemberRepository memberRepository;
-    private final SinittoRepository sinittoRepository;
 
-    public PointAdminController(PointAdminService pointAdminService, MemberRepository memberRepository, SinittoRepository sinittoRepository) {
+    public PointAdminController(PointAdminService pointAdminService, MemberRepository memberRepository) {
         this.pointAdminService = pointAdminService;
         this.memberRepository = memberRepository;
-        this.sinittoRepository = sinittoRepository;
     }
 
     @GetMapping("/admin/point/charge")
@@ -81,24 +76,8 @@ public class PointAdminController {
     @GetMapping("/admin/point/withdraw")
     public String showAllWithdrawRequest(Model model) {
 
-        List<PointLog> pointLogs = pointAdminService.readAllPointWithdrawRequest();
-        List<PointLogWithBankInfo> logWithBankInfos = new ArrayList<>();
+        List<PointLogWithBankInfo> logWithBankInfos = pointAdminService.getPointLogWithBankInfo();
 
-        for (PointLog pointLog : pointLogs) {
-            Sinitto sinitto = sinittoRepository.findByMemberId(pointLog.getMember().getId())
-                    .orElseThrow(() -> new SinittoNotFoundException("시니또를 찾을 수 없습니다"));
-
-            PointLogWithBankInfo pointLogWithBankInfo = new PointLogWithBankInfo(
-                    pointLog.getId(),
-                    pointLog.getPrice(),
-                    pointLog.getPostTime(),
-                    pointLog.getStatus(),
-                    sinitto.getBankName(),
-                    sinitto.getAccountNumber()
-            );
-
-            logWithBankInfos.add(pointLogWithBankInfo);
-        }
         model.addAttribute("logWithBankInfos", logWithBankInfos);
 
         return "point/withdraw";

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.point.service;
 
+import com.example.sinitto.callback.exception.NotSinittoException;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.exception.MemberNotFoundException;
 import com.example.sinitto.member.repository.MemberRepository;
@@ -72,6 +73,10 @@ public class PointService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("요청한 멤버를 찾을 수 없습니다"));
+
+        if(!member.isSinitto()){
+            throw new NotSinittoException("출금 요청은 시니또만 가능합니다. 지금 요청은 시니또가 요청하지 않았습니다.");
+        }
 
         Point point = pointRepository.findByMember(member)
                 .orElseThrow(() -> new PointNotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#77
## 📝 작업 내용
https://github.com/kakao-tech-campus-2nd-step3/Team8_BE/issues/77 (약간 더 디테일한 이슈내용)
### 출금 관리자 페이지에서 Whitelabel Error Page 발생 이유
- **출금 요청 API  에서, 요청자가 시니또인지 검증 하는걸 빼먹었습니다.** ⭐️⭐️⭐️😥
- 이런 상황에서, Admin(출금 관리자 페이지) 관련 로직에서 아래와 같은 코드가 있었습니다.
```java
Sinitto sinitto = sinittoRepository.findByMemberId(pointLog.getMember().getId())
                    .orElseThrow(() -> new SinittoNotFoundException("시니또를 찾을 수 없습니다"));
```
- 시니또가 아닌 멤버가 출금 요청을 한 경우(출금 요청api에서 시니또 인지 아닌지 확인을 안해서 보호자도 출금요청이 가능했어요)
- SinittoNotFoundException 예외가 발생해 Whitelabel Error Page 가 발생한 것으로 파악됩니다.

### 수정 한 것
1. 출금 요청 시 시니또가 인지 아닌지 검증하는 로직 추가하였습니다.
6d86634
2. Admin 로직에서도 시니또가 아닐때 예외를 던지는게 아닌 임시 엔티티 만들어서 반환하는것으로 바꿔보았습니다.
```
이렇게
sinittoRepository.findByMemberId(pointLog.getMember().getId())
                    .orElse(new Sinitto("등록된 계좌 없음", "등록된 계좌 없음", null));
```

7dad2f7



## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #77 
