### PR TITLE
Refactor:  Sinitto 엔터티(계좌데이터) 생성 시점을 변경을 위한 내부로직 수정

### DIFF
--- a/src/main/java/com/example/sinitto/member/entity/Sinitto.java
+++ b/src/main/java/com/example/sinitto/member/entity/Sinitto.java
@@ -11,10 +11,11 @@ public class Sinitto {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @NotNull
+
     private String bankName;
-    @NotNull
+
     private String accountNumber;
+
     @OneToOne
     @JoinColumn(name = "member_id")
     @NotNull
@@ -27,6 +28,10 @@ public class Sinitto {
     public Sinitto(String bankName, String accountNumber, Member member) {
         this.bankName = bankName;
         this.accountNumber = accountNumber;
+        this.member = member;
+    }
+
+    public Sinitto(Member member) {
         this.member = member;
     }
 

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -32,7 +32,7 @@ public class SinittoController {
     @Operation(summary = "계좌정보 등록", description = "시니또가 계좌정보 등록합니다.")
     @PostMapping("/bank")
     public ResponseEntity<String> createSeniorBankInfo(@MemberId Long memberId, @RequestBody SinittoBankRequest sinittoBankRequest) {
-        sinittoService.createSinittoBankInfo(memberId, sinittoBankRequest);
+        sinittoService.updateSinittoBankInfo(memberId, sinittoBankRequest);
         return ResponseEntity.ok("계좌등록되었습니다.");
     }
 

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -25,16 +25,6 @@ public class SinittoService {
         this.sinittoRepository = sinittoRepository;
     }
 
-
-    @Transactional
-    public void createSinittoBankInfo(Long memberId, SinittoBankRequest sinittoBankRequest) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new MemberNotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
-        );
-        Sinitto sinitto = new Sinitto(sinittoBankRequest.bankName(), sinittoBankRequest.accountNumber(), member);
-        sinittoRepository.save(sinitto);
-    }
-
     @Transactional(readOnly = true)
     public SinittoResponse readSinitto(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(

--- a/src/test/java/com/example/sinitto/sinitto/entity/SinittoTest.java
+++ b/src/test/java/com/example/sinitto/sinitto/entity/SinittoTest.java
@@ -2,76 +2,57 @@ package com.example.sinitto.sinitto.entity;
 
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Sinitto;
-import com.example.sinitto.sinitto.repository.SinittoRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
-@DataJpaTest
 class SinittoTest {
-
-    @Mock
-    private SinittoRepository sinittoRepository;
 
     private Sinitto sinitto;
     private Member member;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         member = new Member("John Doe", "123-4567", "johndoe@example.com", true);
         sinitto = new Sinitto("Bank A", "987654321", member);
     }
 
     @Test
+    @DisplayName("Sinitto 생성 테스트")
     void testCreateSinitto() {
-        when(sinittoRepository.save(sinitto)).thenReturn(sinitto);
-
-        Sinitto savedSinitto = sinittoRepository.save(sinitto);
-
-        assertNotNull(savedSinitto);
-        assertEquals("Bank A", savedSinitto.getBankName());
-        assertEquals("987654321", savedSinitto.getAccountNumber());
-        assertEquals(member, savedSinitto.getMember());
-
-        verify(sinittoRepository, times(1)).save(sinitto);
+        assertNotNull(sinitto);
+        assertEquals("Bank A", sinitto.getBankName());
+        assertEquals("987654321", sinitto.getAccountNumber());
+        assertEquals(member, sinitto.getMember());
     }
 
     @Test
+    @DisplayName("Member만으로 Sinitto 생성 테스트")
+    void testCreateSinittoWithOnlyMember() {
+        Sinitto sinittoWithOnlyMember = new Sinitto(member);
+
+        assertNotNull(sinittoWithOnlyMember);
+        assertEquals(member, sinittoWithOnlyMember.getMember());
+        assertNull(sinittoWithOnlyMember.getBankName());
+        assertNull(sinittoWithOnlyMember.getAccountNumber());
+    }
+
+    @Test
+    @DisplayName("Sinitto 업데이트 테스트")
     void testUpdateSinitto() {
         sinitto.updateSinitto("Bank B", "123456789");
 
-        when(sinittoRepository.save(sinitto)).thenReturn(sinitto);
-
-        Sinitto updatedSinitto = sinittoRepository.save(sinitto);
-
-        assertNotNull(updatedSinitto);
-        assertEquals("Bank B", updatedSinitto.getBankName());
-        assertEquals("123456789", updatedSinitto.getAccountNumber());
-
-        verify(sinittoRepository, times(1)).save(sinitto);
+        assertEquals("Bank B", sinitto.getBankName());
+        assertEquals("123456789", sinitto.getAccountNumber());
     }
 
     @Test
-    void testFindSinittoById() {
-        when(sinittoRepository.findById(1L)).thenReturn(Optional.of(sinitto));
-
-        Optional<Sinitto> foundSinitto = sinittoRepository.findById(1L);
-
-        assertTrue(foundSinitto.isPresent());
-        assertEquals(sinitto.getId(), foundSinitto.get().getId());
-    }
-
-    @Test
-    void testDeleteSinitto() {
-        sinittoRepository.delete(sinitto);
-        verify(sinittoRepository, times(1)).delete(sinitto);
+    @DisplayName("Sinitto Getter 테스트")
+    void testGetters() {
+        assertEquals("Bank A", sinitto.getBankName());
+        assertEquals("987654321", sinitto.getAccountNumber());
+        assertEquals(member, sinitto.getMember());
     }
 }

--- a/src/test/java/com/example/sinitto/sinitto/repository/SinittoRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/sinitto/repository/SinittoRepositoryTest.java
@@ -4,6 +4,7 @@ import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Sinitto;
 import com.example.sinitto.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -29,30 +30,32 @@ class SinittoRepositoryTest {
         member = new Member("John Doe", "123-4567", "johndoe@example.com", true);
         memberRepository.save(member);
 
-        sinitto = new Sinitto("Bank A", "987654321", member);
+        // Member만으로 생성하는 생성자 사용
+        sinitto = new Sinitto(member);
         sinittoRepository.save(sinitto);
     }
 
     @Test
+    @DisplayName("회원 ID로 Sinitto 찾기 테스트")
     void testFindByMemberId() {
         Optional<Sinitto> foundSinitto = sinittoRepository.findByMemberId(member.getId());
         assertTrue(foundSinitto.isPresent());
-        assertEquals(sinitto.getBankName(), foundSinitto.get().getBankName());
+        assertEquals(sinitto.getMember(), foundSinitto.get().getMember());
     }
 
     @Test
+    @DisplayName("Sinitto 저장 테스트")
     void testSaveSinitto() {
         Member newMember = new Member("Jane Doe", "987-6543", "janedoe@example.com", true);
         memberRepository.save(newMember);
-
-        Sinitto newSinitto = new Sinitto("Bank B", "123456789", newMember);
+        Sinitto newSinitto = new Sinitto(newMember);
         Sinitto savedSinitto = sinittoRepository.save(newSinitto);
         assertNotNull(savedSinitto);
-        assertEquals("Bank B", savedSinitto.getBankName());
+        assertEquals(newMember, savedSinitto.getMember());
     }
 
-
     @Test
+    @DisplayName("Sinitto 삭제 테스트")
     void testDeleteSinitto() {
         sinittoRepository.delete(sinitto);
         Optional<Sinitto> deletedSinitto = sinittoRepository.findById(sinitto.getId());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
>  - #82


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- Sinitto엔터티 생성자 추가 및 일부 속성 @NotNull 삭제
- SinittoService의 createSinittoBankInfo 메서드 삭제
- SinittoController에서 계좌 등록 api의 사용 메서드 변경

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

>서비스 레이어에서는 계좌수정, 계좌등록 메서드를 합쳤는데, 컨트롤러 레이어도 그렇게 하는 것이 좋을까요? 지금은 api가 구분되어있어서 다들 어떻게 생각하시는지 궁금합니다.

## ⏰ 현재 버그


## ✏ Git Close
> close #82 
> 
