### PR TITLE
Deploy: PR 생성시 테스트코드 수행 로직 구현

### DIFF
--- a/.github/workflows/testcode.yml
+++ b/.github/workflows/testcode.yml
@@ -1,0 +1,23 @@
+name: Run Tests on Pull Request
+
+on:
+  pull_request:
+    branches:
+      - Weekly
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Run Tests
+        run: ./gradlew test

--- a/.github/workflows/testcode.yml
+++ b/.github/workflows/testcode.yml
@@ -9,6 +9,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/testcode.yml
+++ b/.github/workflows/testcode.yml
@@ -20,4 +20,6 @@ jobs:
           distribution: 'temurin'
 
       - name: Run Tests
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: ./gradlew test

--- a/src/test/java/com/example/sinitto/SinittoApplicationTests.java
+++ b/src/test/java/com/example/sinitto/SinittoApplicationTests.java
@@ -1,13 +1,20 @@
 package com.example.sinitto;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 
 @SpringBootTest
 class SinittoApplicationTests {
 
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
     @Test
     void contextLoads() {
+        assertNotNull(jwtSecret);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #93 

## 📝 작업 내용
- PR 생성시 테스트코드 수행 로직 추가
- jwt.secret키를 깃허브 시크릿에 저장 및 환경변수 설정
- 테스트코드에서 환경변수를 읽어오도록 설정
- 도커를 사용하여 레디스 환경 구축

## ⏰ 현재 버그
없습니다

## ✏ Git Close
close #93 
