### PR TITLE
Fix: 안부전화 Cascade 순환참조 문제 해결 및 관계성 오류 해결 구현

### DIFF
--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -35,17 +35,17 @@ public class HelloCall {
     @Enumerated(EnumType.STRING)
     private HelloCall.Status status;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "senior_id")
     @NotNull
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Senior senior;
-    @OneToMany(mappedBy = "helloCall", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "helloCall")
     private List<TimeSlot> timeSlots = new ArrayList<>();
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
-    @OneToMany(mappedBy = "helloCall", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "helloCall")
     private List<HelloCallTimeLog> helloCallTimeLogs = new ArrayList<>();
 
     public HelloCall(LocalDate startDate, LocalDate endDate, int price, int serviceTime, String requirement, Senior senior) {

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
@@ -2,6 +2,8 @@ package com.example.sinitto.helloCall.entity;
 
 import com.example.sinitto.member.entity.Member;
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -14,9 +16,11 @@ public class HelloCallTimeLog {
     private LocalDateTime startDateAndTime;
     private LocalDateTime endDateAndTime;
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "helloCall_id")
     private HelloCall helloCall;
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "sinitto_id")
     private Member member;
 

--- a/src/main/java/com/example/sinitto/helloCall/entity/TimeSlot.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/TimeSlot.java
@@ -3,6 +3,8 @@ package com.example.sinitto.helloCall.entity;
 import com.example.sinitto.helloCall.exception.TimeRuleException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalTime;
 
@@ -19,6 +21,7 @@ public class TimeSlot {
     @NotNull
     private LocalTime endTime;
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "hellocall_id")
     private HelloCall helloCall;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #99 

## 📝 작업 내용
- HelloCall, TimeCallTimeLog, TimeSlot에서 JPA를 통한 Cascade를 적용하니 참조순환 문제가 생겨서 DDL단에서 미리 적용시키는 OnDelete 사용으로 변환
- HelloCall과 Senior 엔티티 관계 1:1에서 N:1로 수정

## ⏰ 현재 버그
테스트 코드 구동 결과 이상 없습니다.

## ✏ Git Close
close #99 