### PR TITLE
Feat: 시니또용 카테고리별 가이드라인 조회 api 추가 및 기존 api 삭제 (프론트 요청)

### DIFF
--- a/src/main/java/com/example/sinitto/guardGuideline/controller/GuardGuidelineController.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/controller/GuardGuidelineController.java
@@ -38,8 +38,8 @@ public class GuardGuidelineController {
 
     @Operation(summary = "카테고리에 해당하는 모든 가이드라인 조회(시니또용)", description = "시니또용 앱에서 카테고리에 해당하는 모든 가이드라인들을 요청할 때 필요합니다.")
     @GetMapping("/sinitto/{callbackId}/{type}")
-    public ResponseEntity<List<GuardGuidelineResponse>> getGuardGuidelinesByCategoryAndCallback(@PathVariable Long callbackId, @PathVariable GuardGuideline.Type type) {
-        return ResponseEntity.ok(guardGuidelineService.readAllGuardGuidelinesByCategoryAndCallback(callbackId, type));
+    public ResponseEntity<List<GuardGuidelineResponse>> getGuardGuidelinesByCategoryAndCallback(@MemberId Long memberId, @PathVariable Long callbackId, @PathVariable GuardGuideline.Type type) {
+        return ResponseEntity.ok(guardGuidelineService.readAllGuardGuidelinesByCategoryAndCallback(memberId, callbackId, type));
     }
 
     @Operation(summary = "가이드라인 수정", description = "보호자가 특정 가이드라인을 수정할 때 필요합니다.")

--- a/src/main/java/com/example/sinitto/guardGuideline/controller/GuardGuidelineController.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/controller/GuardGuidelineController.java
@@ -30,10 +30,16 @@ public class GuardGuidelineController {
         return ResponseEntity.ok("가이드라인이 추가되었습니다.");
     }
 
-    @Operation(summary = "카테고리에 해당하는 모든 가이드라인 조회", description = "시니또용 앱에서 카테고리에 해당하는 모든 가이드라인들을 요청할 때 필요합니다.")
-    @GetMapping("/{seniorId}/{type}")
-    public ResponseEntity<List<GuardGuidelineResponse>> getGuardGuidelinesByCategory(@PathVariable Long seniorId, @PathVariable GuardGuideline.Type type) {
-        return ResponseEntity.ok(guardGuidelineService.readAllGuardGuidelinesByCategory(seniorId, type));
+    @Operation(summary = "카테고리에 해당하는 모든 가이드라인 조회(보호자용)", description = "보호자용 앱에서 카테고리에 해당하는 모든 가이드라인들을 요청할 때 필요합니다.")
+    @GetMapping("/guard/{seniorId}/{type}")
+    public ResponseEntity<List<GuardGuidelineResponse>> getGuardGuidelinesByCategoryAndSenior(@MemberId Long memberId, @PathVariable Long seniorId, @PathVariable GuardGuideline.Type type) {
+        return ResponseEntity.ok(guardGuidelineService.readAllGuardGuidelinesByCategoryAndSenior(memberId, seniorId, type));
+    }
+
+    @Operation(summary = "카테고리에 해당하는 모든 가이드라인 조회(시니또용)", description = "시니또용 앱에서 카테고리에 해당하는 모든 가이드라인들을 요청할 때 필요합니다.")
+    @GetMapping("/sinitto/{callbackId}/{type}")
+    public ResponseEntity<List<GuardGuidelineResponse>> getGuardGuidelinesByCategoryAndCallback(@PathVariable Long callbackId, @PathVariable GuardGuideline.Type type) {
+        return ResponseEntity.ok(guardGuidelineService.readAllGuardGuidelinesByCategoryAndCallback(callbackId, type));
     }
 
     @Operation(summary = "가이드라인 수정", description = "보호자가 특정 가이드라인을 수정할 때 필요합니다.")
@@ -50,11 +56,6 @@ public class GuardGuidelineController {
         return ResponseEntity.ok(guardGuidelineService.readAllGuardGuidelinesBySenior(memberId, seniorId));
     }
 
-    @Operation(summary = "특정 가이드라인 조회", description = "보호자용 API입니다.")
-    @GetMapping("/detail")
-    public ResponseEntity<GuardGuidelineResponse> getGuardGuideline(@RequestParam("callbackId") Long callbackId, @RequestParam("guidelineId") Long guidelineId) {
-        return ResponseEntity.ok(guardGuidelineService.readGuardGuideline(callbackId, guidelineId));
-    }
 
     @Operation(summary = "특정 가이드라인 삭제", description = "보호자용 API입니다.")
     @DeleteMapping("/delete")

--- a/src/main/java/com/example/sinitto/guardGuideline/controller/GuardGuidelineController.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/controller/GuardGuidelineController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/guardguidelines")
-@Tag(name = "보호자용 가이드라인", description = "보호자가 입력하는 시니어별 가이드라인 관련 API")
+@Tag(name = "가이드라인", description = "가이드라인 관련 API")
 public class GuardGuidelineController {
 
     private final GuardGuidelineService guardGuidelineService;

--- a/src/main/java/com/example/sinitto/guardGuideline/service/GuardGuidelineService.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/service/GuardGuidelineService.java
@@ -43,7 +43,29 @@ public class GuardGuidelineService {
     }
 
     @Transactional(readOnly = true)
-    public List<GuardGuidelineResponse> readAllGuardGuidelinesByCategory(Long seniorId, Type type) {
+    public List<GuardGuidelineResponse> readAllGuardGuidelinesByCategoryAndSenior(Long memberId, Long seniorId, Type type) {
+        List<GuardGuideline> guardGuidelines = guardGuidelineRepository.findBySeniorIdAndType(seniorId, type);
+        Senior senior = seniorRepository.findById(seniorId).orElseThrow(
+                () -> new NotFoundException("시니어를 찾을 수 없습니다.")
+        );
+        if (senior.isNotGuard(memberId)) {
+            throw new BadRequestException("해당 Guard의 Senior가 아닙니다.");
+        }
+        return guardGuidelines.stream()
+                .map(m -> new GuardGuidelineResponse(m.getId(), m.getType(), m.getTitle(), m.getContent()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<GuardGuidelineResponse> readAllGuardGuidelinesByCategoryAndCallback(Long callbackId, Type type) {
+        Callback callback = callbackRepository.findById(callbackId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 콜백입니다"));
+
+        if (callback.getStatus() != Callback.Status.WAITING.name()) {
+            throw new BadRequestException("해당 콜백은 대기 상태가 아닙니다.");
+        }
+        ;
+        Long seniorId = callback.getSeniorId();
         List<GuardGuideline> guardGuidelines = guardGuidelineRepository.findBySeniorIdAndType(seniorId, type);
 
         return guardGuidelines.stream()
@@ -91,22 +113,5 @@ public class GuardGuidelineService {
         return guardGuidelines.stream()
                 .map(m -> new GuardGuidelineResponse(m.getId(), m.getType(), m.getTitle(), m.getContent()))
                 .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public GuardGuidelineResponse readGuardGuideline(Long callbackId, Long guidelineId) {
-
-        Callback callback = callbackRepository.findById(callbackId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 콜백입니다"));
-
-        GuardGuideline guardGuideline = guardGuidelineRepository.findById(guidelineId).orElseThrow(
-                () -> new NotFoundException("해당 가이드라인이 존재하지 않습니다.")
-        );
-
-        if (!callback.getSenior().equals(guardGuideline.getSenior())) {
-            throw new BadRequestException("해당 Senior의 가이드라인이 아닙니다.");
-        }
-
-        return new GuardGuidelineResponse(guardGuideline.getId(), guardGuideline.getType(), guardGuideline.getTitle(), guardGuideline.getContent());
     }
 }

--- a/src/main/java/com/example/sinitto/guardGuideline/service/GuardGuidelineService.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/service/GuardGuidelineService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 
 @Service
 public class GuardGuidelineService {
@@ -62,7 +61,7 @@ public class GuardGuidelineService {
         Callback callback = callbackRepository.findById(callbackId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 콜백입니다"));
 
-        if (callback.getStatus() != Callback.Status.WAITING.name() && callback.getAssignedMemberId() != memberId){
+        if (callback.getStatus() != Callback.Status.WAITING.name() && callback.getAssignedMemberId() != memberId) {
             throw new BadRequestException("해당 콜백은 대기 상태가 아니고, 배정 시니또가 아닙니다.");
         }
         Long seniorId = callback.getSeniorId();

--- a/src/main/java/com/example/sinitto/guardGuideline/service/GuardGuidelineService.java
+++ b/src/main/java/com/example/sinitto/guardGuideline/service/GuardGuidelineService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class GuardGuidelineService {
@@ -57,14 +58,13 @@ public class GuardGuidelineService {
     }
 
     @Transactional(readOnly = true)
-    public List<GuardGuidelineResponse> readAllGuardGuidelinesByCategoryAndCallback(Long callbackId, Type type) {
+    public List<GuardGuidelineResponse> readAllGuardGuidelinesByCategoryAndCallback(Long memberId, Long callbackId, Type type) {
         Callback callback = callbackRepository.findById(callbackId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 콜백입니다"));
 
-        if (callback.getStatus() != Callback.Status.WAITING.name()) {
-            throw new BadRequestException("해당 콜백은 대기 상태가 아닙니다.");
+        if (callback.getStatus() != Callback.Status.WAITING.name() && callback.getAssignedMemberId() != memberId){
+            throw new BadRequestException("해당 콜백은 대기 상태가 아니고, 배정 시니또가 아닙니다.");
         }
-        ;
         Long seniorId = callback.getSeniorId();
         List<GuardGuideline> guardGuidelines = guardGuidelineRepository.findBySeniorIdAndType(seniorId, type);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> - #109


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 가이드라인 단일 조회 api 삭제
- 서비스 레이어 메서드 구현
- 해당 콜백이 대기 중인지 검증하는 로직 추가 (시니또용)
- 해당 시니어의 보호자인지 검증하는 로직 추가 (보호자용)
- 컨트롤러에 시니또용 카테고리별 가이드라인 조회 api 추가
- Swagger api 테스트
- Swagger @Tag 수정

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 카테고리별 가이드라인 조회 api가 시니또용, 보호자용으로 두 가지라서 url 수정했습니다! 확인해주세요
>


## ⏰ 현재 버그


## ✏ Git Close
> close #109
> 
