### PR TITLE
Deploy: 로컬과 개발 환경에 따라 카카오 리다이렉트 주소를 다르게 리턴하는 로직 구현

### DIFF
--- a/src/main/java/com/example/sinitto/auth/controller/AuthController.java
+++ b/src/main/java/com/example/sinitto/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.example.sinitto.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,8 +42,8 @@ public class AuthController {
 
     @Operation(summary = "Oauth 카카오 인증페이지 리다이렉트", description = "카카오 로그인 화면으로 이동한다.", security = @SecurityRequirement(name = "JWT제외"))
     @GetMapping("/oauth/kakao")
-    public ResponseEntity<Void> redirectToKakaoAuth() {
-        String url = kakaoApiService.getAuthorizationUrl();
+    public ResponseEntity<Void> redirectToKakaoAuth(HttpServletRequest httpServletRequest) {
+        String url = kakaoApiService.getAuthorizationUrl(httpServletRequest);
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create(url));
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
@@ -50,8 +51,8 @@ public class AuthController {
 
     @Operation(summary = "Oauth 카카오 로그인 콜백", description = "카카오 로그인 이후 발생하는 인가코드를 통해 AccessToken과 RefreshToken을 발급한다.", security = @SecurityRequirement(name = "JWT제외"))
     @GetMapping("/oauth/kakao/callback")
-    public ResponseEntity<LoginResponse> kakaoCallback(@RequestParam("code") String code) {
-        LoginResponse loginResponse = memberService.kakaoLogin(code);
+    public ResponseEntity<LoginResponse> kakaoCallback(@RequestParam("code") String code, HttpServletRequest httpServletRequest) {
+        LoginResponse loginResponse = memberService.kakaoLogin(code, httpServletRequest);
         return ResponseEntity.ok().body(loginResponse);
     }
 

--- a/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
@@ -2,8 +2,10 @@ package com.example.sinitto.auth.service;
 
 import com.example.sinitto.auth.dto.KakaoTokenResponse;
 import com.example.sinitto.auth.dto.KakaoUserResponse;
+import com.example.sinitto.common.exception.BadRequestException;
 import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.common.properties.KakaoProperties;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -25,20 +27,42 @@ public class KakaoApiService {
         this.kakaoProperties = kakaoProperties;
     }
 
-    public String getAuthorizationUrl() {
+    public String getAuthorizationUrl(HttpServletRequest httpServletRequest) {
+        String requestUrl = httpServletRequest.getHeader("Referer");
+        String redirectUri;
+
+        if (requestUrl.contains("localhost:5173")) {
+            redirectUri = kakaoProperties.devRedirectUri();
+        } else if (requestUrl.contains("sinitto.s3-website.ap-northeast-2.amazonaws.com")) {
+            redirectUri = kakaoProperties.redirectUri();
+        } else {
+            throw new BadRequestException("해당 도메인에서는 카카오 로그인이 불가합니다. requestUrl : " + requestUrl);
+        }
+
         return KAKAO_AUTH_BASE_URL + "/authorize?response_type=code&client_id="
-                + kakaoProperties.clientId() + "&redirect_uri=" + kakaoProperties.redirectUri();
+                + kakaoProperties.clientId() + "&redirect_uri=" + redirectUri;
     }
 
-    public KakaoTokenResponse getAccessToken(String authorizationCode) {
+    public KakaoTokenResponse getAccessToken(String authorizationCode, HttpServletRequest httpServletRequest) {
         String url = KAKAO_AUTH_BASE_URL + "/token";
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
 
+        String requestUrl = httpServletRequest.getHeader("Origin");
+        String redirectUri;
+
+        if (requestUrl.contains("localhost:5173")) {
+            redirectUri = kakaoProperties.devRedirectUri();
+        } else if (requestUrl.contains("sinitto.s3-website.ap-northeast-2.amazonaws.com")) {
+            redirectUri = kakaoProperties.redirectUri();
+        } else {
+            throw new BadRequestException("해당 도메인에서는 카카오 로그인이 불가합니다. requestUrl : " + requestUrl);
+        }
+
         LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", kakaoProperties.clientId());
-        body.add("redirect_uri", kakaoProperties.redirectUri());
+        body.add("redirect_uri", redirectUri);
         body.add("code", authorizationCode);
 
         RequestEntity<LinkedMultiValueMap<String, String>> request = new RequestEntity<>(body,

--- a/src/main/java/com/example/sinitto/common/properties/KakaoProperties.java
+++ b/src/main/java/com/example/sinitto/common/properties/KakaoProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "kakao")
 public record KakaoProperties(
         String clientId,
-        String redirectUri
+        String redirectUri,
+        String devRedirectUri
 ) {
 }

--- a/src/main/java/com/example/sinitto/member/service/MemberService.java
+++ b/src/main/java/com/example/sinitto/member/service/MemberService.java
@@ -14,6 +14,7 @@ import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.repository.PointRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -47,8 +48,8 @@ public class MemberService implements MemberIdProvider {
         return member.getId();
     }
 
-    public LoginResponse kakaoLogin(String authorizationCode) {
-        KakaoTokenResponse kakaoTokenResponse = kakaoApiService.getAccessToken(authorizationCode);
+    public LoginResponse kakaoLogin(String authorizationCode, HttpServletRequest httpServletRequest) {
+        KakaoTokenResponse kakaoTokenResponse = kakaoApiService.getAccessToken(authorizationCode, httpServletRequest);
         KakaoUserResponse kakaoUserResponse = kakaoApiService.getUserInfo(kakaoTokenResponse.accessToken());
 
         String email = kakaoUserResponse.kakaoAccount().email();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #118 

## 📝 작업 내용
- 카카오 devRedirectUri 추출 로직 추가
- httpServletRequest를 통해 Referer 또는 Origin을 확인하여 다른 프론트 주소 리다이렉트

## ⏰ 현재 버그
서버 배포 후 확인 예정입니다

## ✏ Git Close
close #118 