### PR TITLE
카카오 로그인 요청 헤더 추출 로직에서 NULL 예외처리 구현

### DIFF
--- a/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoApiService.java
@@ -29,6 +29,9 @@ public class KakaoApiService {
 
     public String getAuthorizationUrl(HttpServletRequest httpServletRequest) {
         String requestUrl = httpServletRequest.getHeader("Referer");
+        if (requestUrl == null) {
+            throw new BadRequestException("해당 도메인에서는 카카오 로그인이 불가합니다.");
+        }
         String redirectUri;
 
         if (requestUrl.contains("localhost:5173")) {
@@ -49,6 +52,9 @@ public class KakaoApiService {
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
 
         String requestUrl = httpServletRequest.getHeader("Origin");
+        if (requestUrl == null) {
+            throw new BadRequestException("해당 도메인에서는 카카오 로그인이 불가합니다.");
+        }
         String redirectUri;
 
         if (requestUrl.contains("localhost:5173")) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #121 

## 📝 작업 내용
- 카카오 로그인 요청 헤더 추출 로직에서 NULL 예외처리 구현

## ⏰ 현재 버그
없습니다

## ✏ Git Close
close #121 
