### PR TITLE
Feat: 콜백 단건 조회 로직 개선

### DIFF
--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -234,8 +234,11 @@ public class CallbackService {
         Callback callback = callbackRepository.findById(callbackId)
                 .orElseThrow(() -> new NotFoundException("해당 콜백 id에 해당하는 콜백이 없습니다."));
 
-        if (callback.getAssignedMemberId().equals(memberId)) {
-            return new CallbackForSinittoResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus(), callback.getSeniorId(), true, callback.getSenior().getPhoneNumber());
+        if (!callback.getStatus().equals(Callback.Status.WAITING.toString())) {
+            if (callback.getAssignedMemberId() != null && callback.getAssignedMemberId().equals(memberId)) {
+                return new CallbackForSinittoResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus(), callback.getSeniorId(), true, callback.getSenior().getPhoneNumber());
+            }
+            throw new ForbiddenException("대기중인 콜백이 아닌경우 오직 할당받은 시니또만이 콜백을 조회할 수 있습니다.");
         }
 
         return new CallbackForSinittoResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus(), callback.getSeniorId(), false, "");

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -406,7 +406,7 @@ class CallbackServiceTest {
     }
 
     @Test
-    @DisplayName("시니또용 콜백 단건 조회 - api 호출한 시니또 본인이 할당된 콜백일 경우")
+    @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 아님 + 해당 콜백에 할당 된 시니또 맞음 ")
     void getCallbackForSinitto() {
         //given
         Long memberId = 1L;
@@ -415,11 +415,12 @@ class CallbackServiceTest {
         Senior senior = mock(Senior.class);
 
         when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+
+        when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
         when(callback.getAssignedMemberId()).thenReturn(1L);
         when(callback.getId()).thenReturn(1L);
         when(callback.getSeniorName()).thenReturn("SeniorName");
         when(callback.getPostTime()).thenReturn(LocalDateTime.now());
-        when(callback.getStatus()).thenReturn(Callback.Status.WAITING.toString());
         when(callback.getSeniorId()).thenReturn(1L);
         when(callback.getSenior()).thenReturn(senior);
         when(callback.getSenior().getPhoneNumber()).thenReturn("01012341234");
@@ -429,10 +430,11 @@ class CallbackServiceTest {
 
         //then
         assertTrue(result.isAssignedToSelf());
+        assertEquals("01012341234", result.seniorPhoneNumber());
     }
 
     @Test
-    @DisplayName("시니또용 콜백 단건 조회 - api 호출한 시니또 본인이 할당된 콜백이 아닌 경우")
+    @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 인 상황 ")
     void getCallbackForSinitto2() {
         //given
         Long memberId = 1L;
@@ -440,17 +442,45 @@ class CallbackServiceTest {
         Callback callback = mock(Callback.class);
 
         when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getAssignedMemberId()).thenReturn(999L); // 여기서 시니또 본인에게 할당된 콜백이 아닌걸 확인
-        when(callback.getId()).thenReturn(1L);
-        when(callback.getSeniorName()).thenReturn("SeniorName");
-        when(callback.getPostTime()).thenReturn(LocalDateTime.now());
+        when(callback.getAssignedMemberId()).thenReturn(null);
+        when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
+
+        //when then
+        assertThrows(ForbiddenException.class, () -> callbackService.getCallbackForSinitto(memberId, callbackId));
+    }
+
+    @Test
+    @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 은 아닌데 해당 콜백에 할당된 시니또는 아닌 상황")
+    void getCallbackForSinitto3() {
+        //given
+        Long memberId = 1L;
+        Long callbackId = 1L;
+        Callback callback = mock(Callback.class);
+
+        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+        when(callback.getAssignedMemberId()).thenReturn(999L);
+        when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
+
+        //when then
+        assertThrows(ForbiddenException.class, () -> callbackService.getCallbackForSinitto(memberId, callbackId));
+    }
+
+    @Test
+    @DisplayName("시니또용 콜백 단건 조회 - 1.콜백이 '대기상태' 인 경우(모든 시니또가 조회 가능하다)")
+    void getCallbackForSinitto4() {
+        //given
+        Long memberId = 1L;
+        Long callbackId = 1L;
+        Callback callback = mock(Callback.class);
+
+        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
         when(callback.getStatus()).thenReturn(Callback.Status.WAITING.toString());
-        when(callback.getSeniorId()).thenReturn(1L);
 
         //when
         CallbackForSinittoResponse result = callbackService.getCallbackForSinitto(memberId, callbackId);
 
         //then
         assertFalse(result.isAssignedToSelf());
+        assertEquals("", result.seniorPhoneNumber());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#119

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)


### 상태에 따른 검증 로직 추가
변경된 코드에서는 먼저 callback의 status가 WAITING인지 확인합니다.
만약 WAITING 상태가 아닌 경우, callback.getAssignedMemberId()가 null이 아니고, memberId와 일치하는지 확인하여 해당 콜백이 할당된 사용자만 접근할 수 있도록 제한.


개선점: WAITING이 아닌 상태에서는 오직 할당된 시니또만 접근할 수 있도록 하였습니다!

### 예외 처리 추가
WAITING 상태가 아니면서 할당된 시니또가 아닌 경우, ForbiddenException을 발생시키도록 했습니다.


개선점: 대기 중이 아닌 콜백에 대해 권한이 없는 멤버가 접근하려 할 때 예외를 던지는 로직 추가.

### 버그 수정
기존에 callback 엔티티에서 `Long assignedMemberId = null`(아직 대기중인 할당되지 않은 콜백) 때문에 대기중인 콜백을 조회시 `callback.getAssignedMemberId().equals(memberId)`에서 `NullPointerException` 이 발생하여 500 응답에러가 발생하였습니다. null 처리가 미흡하여 발생한 버그로 파악되었습니다. null 처리에 대한 로직 추가하여 해결하였습니다.

> 상황별 테스트 추가

> 스웨거에서 정상적으로 동작되는거 확인 완료
### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 
 
close #119 