### PR TITLE
Feat: 시니또 회원 정보와 계좌 정보 조회 API 및 로직 분리

### DIFF
--- a/src/main/java/com/example/sinitto/guard/dto/GuardRequest.java
+++ b/src/main/java/com/example/sinitto/guard/dto/GuardRequest.java
@@ -2,6 +2,5 @@ package com.example.sinitto.guard.dto;
 
 public record GuardRequest(
         String name,
-        String email,
         String phoneNumber) {
 }

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -39,7 +39,7 @@ public class GuardService {
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
 
-        member.updateMember(guardRequest.name(), guardRequest.email(), guardRequest.phoneNumber());
+        member.updateMember(guardRequest.name(), guardRequest.phoneNumber());
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/member/entity/Member.java
+++ b/src/main/java/com/example/sinitto/member/entity/Member.java
@@ -31,9 +31,8 @@ public class Member {
     protected Member() {
     }
 
-    public void updateMember(String name, String email, String phoneNumber) {
+    public void updateMember(String name, String phoneNumber) {
         this.name = name;
-        this.email = email;
         this.phoneNumber = phoneNumber;
     }
 

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -64,9 +64,4 @@ public class SinittoController {
         return ResponseEntity.ok("시니또 계좌정보가 삭제되었습니다.");
     }
 
-    @Operation(summary = "모든 시니또 조회", description = "관리자용")
-    @GetMapping("/all")
-    public ResponseEntity<List<SinittoResponse>> getAllSinittos() {
-        return ResponseEntity.ok(sinittoService.readAllSinitto());
-    }
 }

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -2,6 +2,7 @@ package com.example.sinitto.sinitto.controller;
 
 import com.example.sinitto.common.annotation.MemberId;
 import com.example.sinitto.sinitto.dto.SinittoBankRequest;
+import com.example.sinitto.sinitto.dto.SinittoBankResponse;
 import com.example.sinitto.sinitto.dto.SinittoRequest;
 import com.example.sinitto.sinitto.dto.SinittoResponse;
 import com.example.sinitto.sinitto.service.SinittoService;
@@ -27,6 +28,12 @@ public class SinittoController {
     @GetMapping
     public ResponseEntity<SinittoResponse> getSinittoInfo(@MemberId Long memberId) {
         return ResponseEntity.ok(sinittoService.readSinitto(memberId));
+    }
+
+    @Operation(summary = "시니또 계좌 정보 조회", description = "시니또의 계좌 정보를 요청한다.")
+    @GetMapping
+    public ResponseEntity<SinittoBankResponse> getSinittoBankInfo(@MemberId Long memberId) {
+        return ResponseEntity.ok(sinittoService.readSinittoBankInfo(memberId));
     }
 
     @Operation(summary = "계좌정보 등록", description = "시니또가 계좌정보 등록합니다.")

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -11,8 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/sinittos")
 @Tag(name = "마이페이지 - 시니또용", description = "시니또 관련 마이페이지 API")

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -57,11 +57,5 @@ public class SinittoController {
         return ResponseEntity.ok("시니또가 삭제되었습니다.");
     }
 
-    @Operation(summary = "시니또 계좌정보 삭제", description = "관리자용")
-    @DeleteMapping("/bank")
-    public ResponseEntity<String> deleteSinittoBankInfo(@MemberId Long memberId) {
-        sinittoService.deleteSinittoBankInfo(memberId);
-        return ResponseEntity.ok("시니또 계좌정보가 삭제되었습니다.");
-    }
 
 }

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -31,7 +31,7 @@ public class SinittoController {
     }
 
     @Operation(summary = "시니또 계좌 정보 조회", description = "시니또의 계좌 정보를 요청한다.")
-    @GetMapping
+    @GetMapping("/bank")
     public ResponseEntity<SinittoBankResponse> getSinittoBankInfo(@MemberId Long memberId) {
         return ResponseEntity.ok(sinittoService.readSinittoBankInfo(memberId));
     }

--- a/src/main/java/com/example/sinitto/sinitto/dto/SinittoRequest.java
+++ b/src/main/java/com/example/sinitto/sinitto/dto/SinittoRequest.java
@@ -3,5 +3,5 @@ package com.example.sinitto.sinitto.dto;
 public record SinittoRequest(
         String name,
         String phoneNumber
-     ) {
+) {
 }

--- a/src/main/java/com/example/sinitto/sinitto/dto/SinittoRequest.java
+++ b/src/main/java/com/example/sinitto/sinitto/dto/SinittoRequest.java
@@ -2,8 +2,6 @@ package com.example.sinitto.sinitto.dto;
 
 public record SinittoRequest(
         String name,
-        String phoneNumber,
-        String email,
-        String accountNumber,
-        String bankName) {
+        String phoneNumber
+     ) {
 }

--- a/src/main/java/com/example/sinitto/sinitto/dto/SinittoResponse.java
+++ b/src/main/java/com/example/sinitto/sinitto/dto/SinittoResponse.java
@@ -3,7 +3,5 @@ package com.example.sinitto.sinitto.dto;
 public record SinittoResponse(
         String name,
         String phoneNumber,
-        String email,
-        String accountNumber,
-        String bankName) {
+        String email) {
 }

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -12,8 +12,6 @@ import com.example.sinitto.sinitto.repository.SinittoBankInfoRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 public class SinittoService {
 
@@ -46,7 +44,7 @@ public class SinittoService {
     @Transactional(readOnly = true)
     public SinittoBankResponse readSinittoBankInfo(Long memberId) {
         SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElse(null);
-        if(sinittoBankInfo == null){
+        if (sinittoBankInfo == null) {
             return new SinittoBankResponse(null, null);
         }
         return new SinittoBankResponse(sinittoBankInfo.getAccountNumber(), sinittoBankInfo.getBankName());

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -56,7 +56,7 @@ public class SinittoService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
-        member.updateMember(sinittoRequest.name(), sinittoRequest.email(), sinittoRequest.phoneNumber());
+        member.updateMember(sinittoRequest.name(), sinittoRequest.phoneNumber());
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -4,6 +4,7 @@ import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.sinitto.dto.SinittoBankRequest;
+import com.example.sinitto.sinitto.dto.SinittoBankResponse;
 import com.example.sinitto.sinitto.dto.SinittoRequest;
 import com.example.sinitto.sinitto.dto.SinittoResponse;
 import com.example.sinitto.sinitto.entity.SinittoBankInfo;
@@ -43,6 +44,14 @@ public class SinittoService {
                 () -> new NotFoundException("이메일에 해당하는 멤버의 계좌정보를 찾을 수 없습니다.")
         );
         return new SinittoResponse(member.getName(), member.getPhoneNumber(), member.getEmail(), sinittoBankInfo.getAccountNumber(), sinittoBankInfo.getBankName());
+    }
+
+    @Transactional(readOnly = true)
+    public SinittoBankResponse readSinittoBankInfo(Long memberId) {
+        SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElseThrow(
+                () -> new NotFoundException("이메일에 해당하는 멤버의 계좌정보를 찾을 수 없습니다.")
+        );
+        return new SinittoBankResponse(sinittoBankInfo.getAccountNumber(), sinittoBankInfo.getBankName());
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -45,9 +45,10 @@ public class SinittoService {
 
     @Transactional(readOnly = true)
     public SinittoBankResponse readSinittoBankInfo(Long memberId) {
-        SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElseThrow(
-                () -> new NotFoundException("이메일에 해당하는 멤버의 계좌정보를 찾을 수 없습니다.")
-        );
+        SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElse(null);
+        if(sinittoBankInfo == null){
+            return new SinittoBankResponse(null, null);
+        }
         return new SinittoBankResponse(sinittoBankInfo.getAccountNumber(), sinittoBankInfo.getBankName());
     }
 

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -40,8 +40,7 @@ public class SinittoService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
-
-        return new SinittoResponse(member.getName(), member.getPhoneNumber(), member.getEmail(), sinittoBankInfo.getAccountNumber(), sinittoBankInfo.getBankName());
+        return new SinittoResponse(member.getName(), member.getPhoneNumber(), member.getEmail());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -75,12 +75,5 @@ public class SinittoService {
         memberRepository.delete(member);
     }
 
-    @Transactional
-    public void deleteSinittoBankInfo(Long memberId) {
-        SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElseThrow(
-                () -> new NotFoundException("이메일에 해당하는 멤버의 계좌정보를 찾을 수 없습니다.")
-        );
-        sinittoBankInfoRepository.delete(sinittoBankInfo);
-    }
 
 }

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -40,9 +40,7 @@ public class SinittoService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
-        SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElseThrow(
-                () -> new NotFoundException("이메일에 해당하는 멤버의 계좌정보를 찾을 수 없습니다.")
-        );
+
         return new SinittoResponse(member.getName(), member.getPhoneNumber(), member.getEmail(), sinittoBankInfo.getAccountNumber(), sinittoBankInfo.getBankName());
     }
 
@@ -84,15 +82,6 @@ public class SinittoService {
                 () -> new NotFoundException("이메일에 해당하는 멤버의 계좌정보를 찾을 수 없습니다.")
         );
         sinittoBankInfoRepository.delete(sinittoBankInfo);
-    }
-
-    @Transactional
-    public List<SinittoResponse> readAllSinitto() {
-        List<SinittoBankInfo> sinittoBankInfos = sinittoBankInfoRepository.findAll();
-
-        return sinittoBankInfos.stream()
-                .map(m -> new SinittoResponse(m.getMember().getName(), m.getMember().getPhoneNumber(), m.getMember().getEmail(), m.getAccountNumber(), m.getBankName()))
-                .toList();
     }
 
 }

--- a/src/test/java/com/example/sinitto/member/entity/MemberTest.java
+++ b/src/test/java/com/example/sinitto/member/entity/MemberTest.java
@@ -31,6 +31,16 @@ public class MemberTest {
     }
 
     @Test
+    @DisplayName("Member 정보 업데이트 테스트")
+    void updateMemberTest() {
+        member.updateMember("updatedName", "01087654321");
+
+        assertThat(member.getName()).isEqualTo("updatedName");
+        assertThat(member.getPhoneNumber()).isEqualTo("01087654321");
+        assertThat(member.getEmail()).isEqualTo("test@test.com");
+    }
+
+    @Test
     @DisplayName("Member SinittoBankInfo 여부 확인 테스트")
     void isSinittoTest() {
         assertThat(member.isSinitto()).isTrue();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> -  #124


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 서비스 레이어 시니또 계좌 정보 조회 메서드 추가
- 컨트롤러 계좌 정보 조회 API 추가
- 중복 url 수정
- SinittoRequest에서 email 삭제
- SinittoResponse에서 계좌 관련 정보삭제
- 계좌정보 삭제 API 삭제
- SWAGGER 멘트 수정
- 시니어 정보 조회 API 전달데이터 변경과 로직 수정
- GuardRequest에서 email 삭제

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 계좌 정보 조회 api 추가했습니다! url은 임의로 정해보았는데 확인해주세요~


## ⏰ 현재 버그
시니또 관련 API 모두 테스트 완료했습니다!

## ✏ Git Close
> close #123 
> 
