### PR TITLE
더미데이터로 로그인 기능 SSR로 구현

### DIFF
--- a/src/main/java/com/example/sinitto/SinittoApplication.java
+++ b/src/main/java/com/example/sinitto/SinittoApplication.java
@@ -1,5 +1,6 @@
 package com.example.sinitto;
 
+import com.example.sinitto.common.properties.DummyProperties;
 import com.example.sinitto.common.properties.KakaoProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,7 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableConfigurationProperties(KakaoProperties.class)
+@EnableConfigurationProperties({KakaoProperties.class, DummyProperties.class})
 @EnableScheduling
 public class SinittoApplication {
 

--- a/src/main/java/com/example/sinitto/common/properties/DummyProperties.java
+++ b/src/main/java/com/example/sinitto/common/properties/DummyProperties.java
@@ -1,0 +1,11 @@
+package com.example.sinitto.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "dummy")
+public record DummyProperties(
+        String devRedirectUri,
+        String redirectUri,
+        String password
+) {
+}

--- a/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Controller
 @RequestMapping("/dummy")
 public class MemberAdminController {
@@ -19,6 +22,11 @@ public class MemberAdminController {
     private final TokenService tokenService;
     private final DummyProperties dummyProperties;
 
+    private final List<String> dummyEmails = Arrays.asList(
+            "1chulsoo@example.com", "2kim@example.com", "3lee@example.com", "4park@example.com", "5choi@example.com",
+            "6jeong@example.com", "7han@example.com", "8oh@example.com", "9lim@example.com", "10song@example.com"
+    );
+
     public MemberAdminController(MemberRepository memberRepository, TokenService tokenService, DummyProperties dummyProperties) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
@@ -26,7 +34,9 @@ public class MemberAdminController {
     }
 
     @GetMapping
-    public String showDummyLoginPage() {
+    public String showDummyLoginPage(Model model) {
+        List<Member> dummyMembers = memberRepository.findAllByEmailIn(dummyEmails);
+        model.addAttribute("members", dummyMembers);
         return "dummy/login";
     }
 
@@ -37,6 +47,9 @@ public class MemberAdminController {
             @RequestParam("env") String env,
             Model model
     ) {
+        List<Member> dummyMembers = memberRepository.findAllByEmailIn(dummyEmails);
+        model.addAttribute("members", dummyMembers);
+
         if (!password.equals(dummyProperties.password())) {
             model.addAttribute("errorMessage", "비밀번호가 일치하지 않습니다.");
             return "dummy/login";

--- a/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
@@ -1,7 +1,6 @@
 package com.example.sinitto.member.controller;
 
 import com.example.sinitto.auth.service.TokenService;
-import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.common.properties.DummyProperties;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;

--- a/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
@@ -2,6 +2,7 @@ package com.example.sinitto.member.controller;
 
 import com.example.sinitto.auth.service.TokenService;
 import com.example.sinitto.common.exception.NotFoundException;
+import com.example.sinitto.common.properties.DummyProperties;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
 import org.springframework.stereotype.Controller;
@@ -16,10 +17,12 @@ public class MemberAdminController {
 
     private final MemberRepository memberRepository;
     private final TokenService tokenService;
+    private final DummyProperties dummyProperties;
 
-    public MemberAdminController(MemberRepository memberRepository, TokenService tokenService) {
+    public MemberAdminController(MemberRepository memberRepository, TokenService tokenService, DummyProperties dummyProperties) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
+        this.dummyProperties = dummyProperties;
     }
 
     @GetMapping
@@ -34,8 +37,9 @@ public class MemberAdminController {
 
         String accessToken = tokenService.generateAccessToken(email);
         String refreshToken = tokenService.generateRefreshToken(email);
+        boolean isSinitto = member.isSinitto();
 
-        String frontendRedirectUrl = "http://localhost:5173/dummy.html";
-        return "redirect:" + frontendRedirectUrl + "?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
+        String frontendRedirectUrl = dummyProperties.devRedirectUri();
+        return "redirect:" + frontendRedirectUrl + "?accessToken=" + accessToken + "&refreshToken=" + refreshToken + "&isSinitto=" + isSinitto;
     }
 }

--- a/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
@@ -1,0 +1,41 @@
+package com.example.sinitto.member.controller;
+
+import com.example.sinitto.auth.service.TokenService;
+import com.example.sinitto.common.exception.NotFoundException;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/dummy")
+public class MemberAdminController {
+
+    private final MemberRepository memberRepository;
+    private final TokenService tokenService;
+
+    public MemberAdminController(MemberRepository memberRepository, TokenService tokenService) {
+        this.memberRepository = memberRepository;
+        this.tokenService = tokenService;
+    }
+
+    @GetMapping
+    public String showDummyLoginPage() {
+        return "dummy/login";
+    }
+
+    @PostMapping
+    public String login(@RequestParam("email") String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("해당 이메일을 가진 멤버를 찾을 수 없습니다."));
+
+        String accessToken = tokenService.generateAccessToken(email);
+        String refreshToken = tokenService.generateRefreshToken(email);
+
+        String frontendRedirectUrl = "http://localhost:5173/dummy.html";
+        return "redirect:" + frontendRedirectUrl + "?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
+    }
+}

--- a/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberAdminController.java
@@ -6,6 +6,7 @@ import com.example.sinitto.common.properties.DummyProperties;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,15 +32,27 @@ public class MemberAdminController {
     }
 
     @PostMapping
-    public String login(@RequestParam("email") String email) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException("해당 이메일을 가진 멤버를 찾을 수 없습니다."));
+    public String login(
+            @RequestParam("email") String email,
+            @RequestParam("password") String password,
+            @RequestParam("env") String env,
+            Model model
+    ) {
+        if (!password.equals(dummyProperties.password())) {
+            model.addAttribute("errorMessage", "비밀번호가 일치하지 않습니다.");
+            return "dummy/login";
+        }
 
+        Member member = memberRepository.findByEmail(email).orElse(null);
+        if (member == null) {
+            model.addAttribute("errorMessage", "해당 이메일을 가진 멤버를 찾을 수 없습니다. 데이터베이스에서 삭제되었는지 확인해주세요.");
+            return "dummy/login";
+        }
         String accessToken = tokenService.generateAccessToken(email);
         String refreshToken = tokenService.generateRefreshToken(email);
         boolean isSinitto = member.isSinitto();
 
-        String frontendRedirectUrl = dummyProperties.devRedirectUri();
+        String frontendRedirectUrl = env.equals("dev") ? dummyProperties.devRedirectUri() : dummyProperties.redirectUri();
         return "redirect:" + frontendRedirectUrl + "?accessToken=" + accessToken + "&refreshToken=" + refreshToken + "&isSinitto=" + isSinitto;
     }
 }

--- a/src/main/java/com/example/sinitto/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/sinitto/member/repository/MemberRepository.java
@@ -15,4 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     List<Member> findByIsSinitto(boolean isSinitto);
+
+    List<Member> findAllByEmailIn(List<String> emails);
+
 }

--- a/src/main/resources/static/css/dummy.css
+++ b/src/main/resources/static/css/dummy.css
@@ -1,0 +1,67 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    margin: 0;
+    padding: 20px;
+}
+
+h2 {
+    color: #333;
+    text-align: center;
+}
+
+p {
+    text-align: center;
+    font-size: 14px;
+}
+
+form {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    max-width: 400px;
+    margin: 20px auto;
+}
+
+label {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 5px;
+}
+
+select,
+input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.button-container {
+    display: flex;
+    justify-content: space-between;
+}
+
+button {
+    background-color: #28a745;
+    color: white;
+    border: none;
+    padding: 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    width: 48%; /* 버튼 너비 조정 */
+}
+
+button:hover {
+    background-color: #218838;
+}
+
+.error-message {
+    color: red;
+    text-align: center;
+    margin-top: 10px;
+}

--- a/src/main/resources/templates/dummy/login.html
+++ b/src/main/resources/templates/dummy/login.html
@@ -5,10 +5,19 @@
 </head>
 <body>
 <h2>로그인</h2>
+<!-- 오류 메시지 출력 -->
+<p th:if="${errorMessage}" th:text="${errorMessage}" style="color: red;"></p>
+
 <form th:action="@{/dummy}" method="post">
     <label for="email">이메일:</label>
-    <input type="email" id="email" name="email" required />
-    <button type="submit">로그인</button>
+    <input type="email" id="email" name="email" required /><br><br>
+
+    <label for="password">비밀번호:</label>
+    <input type="password" id="password" name="password" required /><br><br>
+
+    <!-- 환경 선택 버튼들 -->
+    <button type="submit" name="env" value="dev">개발 환경으로 로그인</button>
+    <button type="submit" name="env" value="prod">배포 서버로 로그인</button>
 </form>
 </body>
 </html>

--- a/src/main/resources/templates/dummy/login.html
+++ b/src/main/resources/templates/dummy/login.html
@@ -1,21 +1,28 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>로그인</title>
+    <title>더미데이터 유저 로그인</title>
 </head>
 <body>
-<h2>로그인</h2>
-<!-- 오류 메시지 출력 -->
+<h2>더미데이터 유저 로그인</h2>
+<p style="color: black; font-weight: bold;">
+    해당 페이지는 개발자용 페이지입니다. 더미데이터 유저만 로그인이 가능합니다.
+</p>
 <p th:if="${errorMessage}" th:text="${errorMessage}" style="color: red;"></p>
 
 <form th:action="@{/dummy}" method="post">
     <label for="email">이메일:</label>
-    <input type="email" id="email" name="email" required/><br><br>
+    <select id="email" name="email" required>
+        <option value="" disabled selected>이메일을 선택하세요</option>
+        <option th:each="member, iterStat : ${members}" th:value="${member.email}"
+                th:text="${member.email + ' (' + (member.isSinitto ? '시니또' : '보호자') + ' ' + (iterStat.index + 1) + ')'}">
+        </option>
+    </select>
+    <br><br>
 
     <label for="password">비밀번호:</label>
     <input type="password" id="password" name="password" required/><br><br>
 
-    <!-- 환경 선택 버튼들 -->
     <button type="submit" name="env" value="dev">개발 환경으로 로그인</button>
     <button type="submit" name="env" value="prod">배포 서버로 로그인</button>
 </form>

--- a/src/main/resources/templates/dummy/login.html
+++ b/src/main/resources/templates/dummy/login.html
@@ -10,10 +10,10 @@
 
 <form th:action="@{/dummy}" method="post">
     <label for="email">이메일:</label>
-    <input type="email" id="email" name="email" required /><br><br>
+    <input type="email" id="email" name="email" required/><br><br>
 
     <label for="password">비밀번호:</label>
-    <input type="password" id="password" name="password" required /><br><br>
+    <input type="password" id="password" name="password" required/><br><br>
 
     <!-- 환경 선택 버튼들 -->
     <button type="submit" name="env" value="dev">개발 환경으로 로그인</button>

--- a/src/main/resources/templates/dummy/login.html
+++ b/src/main/resources/templates/dummy/login.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>더미데이터 유저 로그인</title>
+    <link href="/css/dummy.css" rel="stylesheet">
 </head>
 <body>
 <h2>더미데이터 유저 로그인</h2>
@@ -23,8 +24,10 @@
     <label for="password">비밀번호:</label>
     <input type="password" id="password" name="password" required/><br><br>
 
-    <button type="submit" name="env" value="dev">개발 환경으로 로그인</button>
-    <button type="submit" name="env" value="prod">배포 서버로 로그인</button>
+    <div class="button-container">
+        <button type="submit" name="env" value="dev">개발 환경으로 로그인</button>
+        <button type="submit" name="env" value="prod">배포 서버로 로그인</button>
+    </div>
 </form>
 </body>
 </html>

--- a/src/main/resources/templates/dummy/login.html
+++ b/src/main/resources/templates/dummy/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>로그인</title>
+</head>
+<body>
+<h2>로그인</h2>
+<form th:action="@{/dummy}" method="post">
+    <label for="email">이메일:</label>
+    <input type="email" id="email" name="email" required />
+    <button type="submit">로그인</button>
+</form>
+</body>
+</html>

--- a/src/test/java/com/example/sinitto/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/member/repository/MemberRepositoryTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class MemberRepositoryTest {
@@ -65,6 +67,22 @@ public class MemberRepositoryTest {
         boolean exists = memberRepository.existsByEmail(NotSavedEmail);
 
         assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("이메일 목록을 이용한 멤버 조회 테스트")
+    void findAllByEmailInTest() {
+        Member member1 = new Member("test1", "01011112222", "test1@test.com", true);
+        Member member2 = new Member("test2", "01022223333", "test2@test.com", false);
+        Member member3 = new Member("test3", "01033334444", "test3@test.com", true);
+        memberRepository.saveAll(Arrays.asList(member1, member2, member3));
+
+        List<String> emails = Arrays.asList("test1@test.com", "test3@test.com");
+
+        List<Member> members = memberRepository.findAllByEmailIn(emails);
+
+        assertThat(members).hasSize(2);
+        assertThat(members).extracting("email").containsExactlyInAnyOrder("test1@test.com", "test3@test.com");
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #127 


## 📝 작업 내용
- DummyProperties 추가
- 비밀번호 및 오류 출력 로직 추가
- 더미데이터 이메일 목록에서만 입력하게끔 유도하는 목록 추가
- 추가된 JPQL 테스트코드 추가
- css 추가

### 스크린샷 (선택)
백엔드 로컬, 프론트 깃클론하여 로컬에서 열어 테스트한 결과 영상입니당
https://youtu.be/gAoBiYtJ8bQ


## 💬 리뷰 요구사항(선택)

### 목적
프론트 서버 로그인시 카카오로그인만 제공하기 때문에 더미데이터 로그인을 위한 사이드로그인로직

### 기능 
- '백엔드 도메인 + /dummy' 로 접속
- 10개의 더미데이터 중 하나의 이메일 선택 (더미데이터 제외하고는 선택 불가)
- swagger, postman 등으로 실제 유저 이메일 선택하는 경우를 방지하기 위해 비밀번호 로직 추가
- 비밀번호는 사전에 정의된 공통 비밀번호
- 개발서버 로그인 -> localhost:5173/dummy.html 로 이동
- 배포서버 로그인 -> (프론트배포서버)/dummy.html 로 이동
- 이동시 쿼리파라미터에 백엔드에서 발급받은 accessToken, refreshToken, isSinitto 포함하여 전송
- dummy.html 로직
```
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>JWT Callback</title>
  <style>
    body {
      font-family: Arial, sans-serif;
      text-align: center;
      margin-top: 50px;
    }
  </style>
</head>
<body>
  <h1>JWT Callback</h1>
  <p id="tokenDisplay">유저 정보를 기다리고 있습니다...</p>
  <script>
    const params = new URLSearchParams(window.location.search);
    const accessToken = params.get('accessToken');
    const refreshToken = params.get('refreshToken');
    const isSinitto = params.get('isSinitto');

    const tokenDisplay = document.getElementById('tokenDisplay');

    if (accessToken && refreshToken && isSinitto) {
      // 로컬 스토리지에 토큰 저장
      console.log('Received tokens:', accessToken, refreshToken, isSinitto);
      localStorage.setItem('accessToken', accessToken);
      localStorage.setItem('refreshToken', refreshToken);
      localStorage.setItem('isSinitto', isSinitto);

      tokenDisplay.textContent = '더미데이터 로그인이 완료되었습니다. 잠시만 기다려주세요';

      // isSinitto에 따라 리다이렉트 경로 결정
      setTimeout(() => {
        window.location.href = (isSinitto === 'true') ? '/sinitto' : '/guard';
      }, 2000);
    } else {
      console.error('Access or Refresh token not found in query parameters.');
      tokenDisplay.textContent = 'JWT를 찾을 수 없습니다.';
    }
  </script>
</body>
</html>
```
위와 같습니다
- dummy.html은 설정한 프론트에서 쿼리파라미터를 로컬스토리지에 저장하는 페이지
- 에러시 에러를 throw하지 않고 백엔드 로그인 페이지에만 표시

### 코드
adminController이기 때문에 따로 서비스단을 분리하지 않았습니다
리다이렉트 링크들 및 비밀번호는 gitignore된 dev 속성에 추가하였습니다 -> 카톡방에 공유하겠습니다!

## ⏰ 현재 버그
프론트 코드를 로컬로 열어 테스트했을 때는 문제 없었습니다
배포 서버 테스트는 프론트분께서 dummy.html을 추가해주셔야 테스트 가능합니다

## ✏ Git Close
close #127 
