### PR TITLE
Feat : 각 도메인별 테스트 코드 추가 및 수정 및 각 멤버 별(보호자, 시니또) 할 수 있는 행동 제약 추가

### DIFF
--- a/src/main/java/com/example/sinitto/auth/service/KakaoTokenService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoTokenService.java
@@ -3,8 +3,8 @@ package com.example.sinitto.auth.service;
 import com.example.sinitto.auth.dto.KakaoTokenResponse;
 import com.example.sinitto.auth.entity.KakaoToken;
 import com.example.sinitto.auth.repository.KakaoTokenRepository;
+import com.example.sinitto.common.exception.InvalidJwtException;
 import com.example.sinitto.common.exception.NotFoundException;
-import com.example.sinitto.common.exception.UnauthorizedException;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +40,7 @@ public class KakaoTokenService {
 
         if (kakaoToken.isAccessTokenExpired()) {
             if (kakaoToken.isRefreshTokenExpired()) {
-                throw new UnauthorizedException("카카오 리프레쉬 토큰이 만료되었습니다. 카카오 재 로그인 필요");
+                throw new InvalidJwtException("카카오 리프레쉬 토큰이 만료되었습니다. 카카오 재 로그인 필요");
             }
             KakaoTokenResponse kakaoTokenResponse = kakaoApiService.refreshAccessToken(kakaoToken.getRefreshToken());
             kakaoToken.updateKakaoToken(kakaoTokenResponse.accessToken(), kakaoTokenResponse.refreshToken(), kakaoTokenResponse.expiresIn(), kakaoTokenResponse.refreshTokenExpiresIn());

--- a/src/main/java/com/example/sinitto/auth/service/TokenService.java
+++ b/src/main/java/com/example/sinitto/auth/service/TokenService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class TokenService {
 
-    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 60 * 10;
+    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 10;
     private static final long REFRESH_SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7;
 
     private final Key secretKey;

--- a/src/main/java/com/example/sinitto/auth/service/TokenService.java
+++ b/src/main/java/com/example/sinitto/auth/service/TokenService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class TokenService {
 
-    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 10;
+    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 5;
     private static final long REFRESH_SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7;
 
     private final Key secretKey;

--- a/src/main/java/com/example/sinitto/auth/service/TokenService.java
+++ b/src/main/java/com/example/sinitto/auth/service/TokenService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class TokenService {
 
-    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 5;
+    private static final long ACCESS_FIVE_MINUTES = 1000 * 60 * 5;
     private static final long REFRESH_SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7;
 
     private final Key secretKey;
@@ -36,7 +36,7 @@ public class TokenService {
         return Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TEN_HOURS))
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_FIVE_MINUTES))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -35,12 +35,13 @@ public class GuardService {
     }
 
     @Transactional
-    public void updateGuard(Long memberId, GuardRequest guardRequest) {
+    public Member updateGuard(Long memberId, GuardRequest guardRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
 
         member.updateMember(guardRequest.name(), guardRequest.phoneNumber());
+        return member;
     }
 
     @Transactional
@@ -53,7 +54,7 @@ public class GuardService {
     }
 
     @Transactional
-    public void createSenior(Long memberId, SeniorRequest seniorRequest) {
+    public Senior createSenior(Long memberId, SeniorRequest seniorRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
@@ -61,7 +62,7 @@ public class GuardService {
 
         Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
 
-        seniorRepository.save(senior);
+        return seniorRepository.save(senior);
     }
 
     @Transactional
@@ -81,12 +82,13 @@ public class GuardService {
     }
 
     @Transactional
-    public void updateSenior(Long memberId, Long seniorId, SeniorRequest seniorRequest) {
+    public Senior updateSenior(Long memberId, Long seniorId, SeniorRequest seniorRequest) {
         Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
         );
 
         senior.updateSenior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber());
+        return senior;
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -1,5 +1,6 @@
 package com.example.sinitto.guard.service;
 
+import com.example.sinitto.common.exception.BadRequestException;
 import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.guard.dto.GuardRequest;
 import com.example.sinitto.guard.dto.GuardResponse;
@@ -56,6 +57,7 @@ public class GuardService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
+        if(member.isSinitto()) throw new BadRequestException("보호자만 이용할 수 있습니다.");
 
         Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
 

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -57,7 +57,7 @@ public class GuardService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
-        if(member.isSinitto()) throw new BadRequestException("보호자만 이용할 수 있습니다.");
+        if (member.isSinitto()) throw new BadRequestException("보호자만 이용할 수 있습니다.");
 
         Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
 

--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -35,13 +35,12 @@ public class GuardService {
     }
 
     @Transactional
-    public Member updateGuard(Long memberId, GuardRequest guardRequest) {
+    public void updateGuard(Long memberId, GuardRequest guardRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
 
         member.updateMember(guardRequest.name(), guardRequest.phoneNumber());
-        return member;
     }
 
     @Transactional
@@ -54,7 +53,7 @@ public class GuardService {
     }
 
     @Transactional
-    public Senior createSenior(Long memberId, SeniorRequest seniorRequest) {
+    public void createSenior(Long memberId, SeniorRequest seniorRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
         );
@@ -62,7 +61,7 @@ public class GuardService {
 
         Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
 
-        return seniorRepository.save(senior);
+        seniorRepository.save(senior);
     }
 
     @Transactional
@@ -82,13 +81,12 @@ public class GuardService {
     }
 
     @Transactional
-    public Senior updateSenior(Long memberId, Long seniorId, SeniorRequest seniorRequest) {
+    public void updateSenior(Long memberId, Long seniorId, SeniorRequest seniorRequest) {
         Senior senior = seniorRepository.findByIdAndMemberId(seniorId, memberId).orElseThrow(
                 () -> new NotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
         );
 
         senior.updateSenior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber());
-        return senior;
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
+++ b/src/main/java/com/example/sinitto/sinitto/controller/SinittoController.java
@@ -54,13 +54,4 @@ public class SinittoController {
         sinittoService.updateSinittoBankInfo(memberId, sinittoBankRequest);
         return ResponseEntity.ok("시니또 정보가 수정되었습니다.");
     }
-
-    @Operation(summary = "시니또 삭제", description = "관리자용")
-    @DeleteMapping
-    public ResponseEntity<String> deleteSinitto(@MemberId Long memberId) {
-        sinittoService.deleteSinitto(memberId);
-        return ResponseEntity.ok("시니또가 삭제되었습니다.");
-    }
-
-
 }

--- a/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
+++ b/src/main/java/com/example/sinitto/sinitto/service/SinittoService.java
@@ -65,14 +65,4 @@ public class SinittoService {
         );
         sinittoBankInfo.updateSinitto(sinittoBankRequest.bankName(), sinittoBankRequest.accountNumber());
     }
-
-    @Transactional
-    public void deleteSinitto(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new NotFoundException("이메일에 해당하는 멤버를 찾을 수 없습니다.")
-        );
-        memberRepository.delete(member);
-    }
-
-
 }

--- a/src/test/java/com/example/sinitto/auth/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/KakaoApiServiceTest.java
@@ -36,7 +36,7 @@ public class KakaoApiServiceTest {
 
     @Test
     @DisplayName("getAuthorizationUrl 메소드 테스트 - devUri 포홤 시")
-    void getAuthorizationUrlTestWithDevUri(){
+    void getAuthorizationUrlTestWithDevUri() {
         //given
         when(httpServletRequest.getHeader("Referer")).thenReturn("http://localhost:5173");
         when(kakaoProperties.devRedirectUri()).thenReturn(devRedirectUri);
@@ -55,7 +55,7 @@ public class KakaoApiServiceTest {
 
     @Test
     @DisplayName("getAuthorizationUrl 메소드 테스트 - 배포 uri 포홤 시")
-    void getAuthorizationUrlTestWithAwsUri(){
+    void getAuthorizationUrlTestWithAwsUri() {
         //given
         when(httpServletRequest.getHeader("Referer")).thenReturn("http://sinitto.s3-website.ap-northeast-2.amazonaws.com");
         when(kakaoProperties.redirectUri()).thenReturn(redirectUri);
@@ -74,7 +74,7 @@ public class KakaoApiServiceTest {
 
     @Test
     @DisplayName("getAuthorizationUrl 메소드 테스트 - 이외의 주소 포함 시 실패")
-    void getAuthorizationUrlTestWithAnotherUri(){
+    void getAuthorizationUrlTestWithAnotherUri() {
         //given
         when(httpServletRequest.getHeader("Referer")).thenReturn("http://test-uri.com");
 
@@ -84,7 +84,7 @@ public class KakaoApiServiceTest {
 
     @Test
     @DisplayName("getAuthorizationUrl 메소드 테스트 - 주소가 null일 시 실패")
-    void getAuthorizationUrlTestWithNullUri(){
+    void getAuthorizationUrlTestWithNullUri() {
         //given
         when(httpServletRequest.getHeader("Referer")).thenReturn(null);
 

--- a/src/test/java/com/example/sinitto/auth/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/KakaoApiServiceTest.java
@@ -25,7 +25,7 @@ public class KakaoApiServiceTest {
     @Value("kakao.clientId")
     private String clientId;
 
-    @Value("kakako.devRedirectUri")
+    @Value("kakao.devRedirectUri")
     private String devRedirectUri;
 
     @Value("kakao.redirectUri")

--- a/src/test/java/com/example/sinitto/auth/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/KakaoApiServiceTest.java
@@ -1,0 +1,94 @@
+package com.example.sinitto.auth.service;
+
+import com.example.sinitto.common.exception.BadRequestException;
+import com.example.sinitto.common.properties.KakaoProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.beans.factory.annotation.Value;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class KakaoApiServiceTest {
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Mock
+    private KakaoProperties kakaoProperties;
+
+    @Value("kakao.clientId")
+    private String clientId;
+
+    @Value("kakako.devRedirectUri")
+    private String devRedirectUri;
+
+    @Value("kakao.redirectUri")
+    private String redirectUri;
+
+    @InjectMocks
+    KakaoApiService kakaoApiService;
+
+    @Test
+    @DisplayName("getAuthorizationUrl 메소드 테스트 - devUri 포홤 시")
+    void getAuthorizationUrlTestWithDevUri(){
+        //given
+        when(httpServletRequest.getHeader("Referer")).thenReturn("http://localhost:5173");
+        when(kakaoProperties.devRedirectUri()).thenReturn(devRedirectUri);
+        when(kakaoProperties.clientId()).thenReturn(clientId);
+
+        //when
+        String result = kakaoApiService.getAuthorizationUrl(httpServletRequest);
+        String expect = "https://kauth.kakao.com/oauth" + "/authorize?response_type=code&client_id="
+                + clientId
+                + "&redirect_uri="
+                + devRedirectUri;
+
+        //then
+        assertEquals(result, expect);
+    }
+
+    @Test
+    @DisplayName("getAuthorizationUrl 메소드 테스트 - 배포 uri 포홤 시")
+    void getAuthorizationUrlTestWithAwsUri(){
+        //given
+        when(httpServletRequest.getHeader("Referer")).thenReturn("http://sinitto.s3-website.ap-northeast-2.amazonaws.com");
+        when(kakaoProperties.redirectUri()).thenReturn(redirectUri);
+        when(kakaoProperties.clientId()).thenReturn(clientId);
+
+        //when
+        String result = kakaoApiService.getAuthorizationUrl(httpServletRequest);
+        String expect = "https://kauth.kakao.com/oauth" + "/authorize?response_type=code&client_id="
+                + clientId
+                + "&redirect_uri="
+                + redirectUri;
+
+        //then
+        assertEquals(result, expect);
+    }
+
+    @Test
+    @DisplayName("getAuthorizationUrl 메소드 테스트 - 이외의 주소 포함 시 실패")
+    void getAuthorizationUrlTestWithAnotherUri(){
+        //given
+        when(httpServletRequest.getHeader("Referer")).thenReturn("http://test-uri.com");
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> kakaoApiService.getAuthorizationUrl(httpServletRequest));
+    }
+
+    @Test
+    @DisplayName("getAuthorizationUrl 메소드 테스트 - 주소가 null일 시 실패")
+    void getAuthorizationUrlTestWithNullUri(){
+        //given
+        when(httpServletRequest.getHeader("Referer")).thenReturn(null);
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> kakaoApiService.getAuthorizationUrl(httpServletRequest));
+    }
+}

--- a/src/test/java/com/example/sinitto/auth/service/KakaoTokenServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/KakaoTokenServiceTest.java
@@ -26,7 +26,7 @@ public class KakaoTokenServiceTest {
 
     @Test
     @DisplayName("saveKakaoToken 메소드 테스트")
-    void saveKakaoTokenTestInRepository(){
+    void saveKakaoTokenTestInRepository() {
         //given
         String email = "test@email.com";
         KakaoTokenResponse kakaoTokenResponse = mock(KakaoTokenResponse.class);
@@ -43,25 +43,25 @@ public class KakaoTokenServiceTest {
         verify(kakaoTokenRepository, times(1)).save(any(KakaoToken.class));
     }
 
-   @Test
-   @DisplayName("getValidAccessTokenInServer 메소드 테스트 - accessToken 만료 전")
-   void getValidAccessTokenInServerTestWhenAccessTokenIsNotExpired(){
-       //given
-       String email = "test@email.com";
-       KakaoToken kakaoToken = mock(KakaoToken.class);
+    @Test
+    @DisplayName("getValidAccessTokenInServer 메소드 테스트 - accessToken 만료 전")
+    void getValidAccessTokenInServerTestWhenAccessTokenIsNotExpired() {
+        //given
+        String email = "test@email.com";
+        KakaoToken kakaoToken = mock(KakaoToken.class);
 
-       when(kakaoTokenRepository.findByMemberEmail(email)).thenReturn(Optional.of(kakaoToken));
-       when(kakaoToken.isAccessTokenExpired()).thenReturn(false);
-       //when
+        when(kakaoTokenRepository.findByMemberEmail(email)).thenReturn(Optional.of(kakaoToken));
+        when(kakaoToken.isAccessTokenExpired()).thenReturn(false);
+        //when
         String result = kakaoTokenService.getValidAccessTokenInServer(email);
 
-       //then
-       assertEquals(kakaoToken.getAccessToken(), result);
-   }
+        //then
+        assertEquals(kakaoToken.getAccessToken(), result);
+    }
 
     @Test
     @DisplayName("getValidAccessTokenInServer 메소드 테스트 - accessToken 및 refreshToken 만료 후")
-    void getValidAccessTokenInServerTestWhenAccessTokenAndRefreshTokenIsExpired(){
+    void getValidAccessTokenInServerTestWhenAccessTokenAndRefreshTokenIsExpired() {
         //given
         String email = "test@email.com";
         KakaoToken kakaoToken = mock(KakaoToken.class);

--- a/src/test/java/com/example/sinitto/auth/service/KakaoTokenServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/KakaoTokenServiceTest.java
@@ -1,0 +1,76 @@
+package com.example.sinitto.auth.service;
+
+import com.example.sinitto.auth.dto.KakaoTokenResponse;
+import com.example.sinitto.auth.entity.KakaoToken;
+import com.example.sinitto.auth.repository.KakaoTokenRepository;
+import com.example.sinitto.common.exception.InvalidJwtException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class KakaoTokenServiceTest {
+    @Mock
+    private KakaoTokenRepository kakaoTokenRepository;
+
+    @InjectMocks
+    private KakaoTokenService kakaoTokenService;
+
+    @Test
+    @DisplayName("saveKakaoToken 메소드 테스트")
+    void saveKakaoTokenTestInRepository(){
+        //given
+        String email = "test@email.com";
+        KakaoTokenResponse kakaoTokenResponse = mock(KakaoTokenResponse.class);
+        KakaoToken kakaoToken = mock(KakaoToken.class);
+
+        when(kakaoTokenRepository.findByMemberEmail(email)).thenReturn(Optional.of(kakaoToken));
+
+        //when
+        kakaoTokenService.saveKakaoToken(email, kakaoTokenResponse);
+
+        //then
+        verify(kakaoToken, times(1)).updateKakaoToken(kakaoTokenResponse.accessToken(), kakaoTokenResponse.refreshToken(),
+                kakaoTokenResponse.expiresIn(), kakaoTokenResponse.refreshTokenExpiresIn());
+        verify(kakaoTokenRepository, times(1)).save(any(KakaoToken.class));
+    }
+
+   @Test
+   @DisplayName("getValidAccessTokenInServer 메소드 테스트 - accessToken 만료 전")
+   void getValidAccessTokenInServerTestWhenAccessTokenIsNotExpired(){
+       //given
+       String email = "test@email.com";
+       KakaoToken kakaoToken = mock(KakaoToken.class);
+
+       when(kakaoTokenRepository.findByMemberEmail(email)).thenReturn(Optional.of(kakaoToken));
+       when(kakaoToken.isAccessTokenExpired()).thenReturn(false);
+       //when
+        String result = kakaoTokenService.getValidAccessTokenInServer(email);
+
+       //then
+       assertEquals(kakaoToken.getAccessToken(), result);
+   }
+
+    @Test
+    @DisplayName("getValidAccessTokenInServer 메소드 테스트 - accessToken 및 refreshToken 만료 후")
+    void getValidAccessTokenInServerTestWhenAccessTokenAndRefreshTokenIsExpired(){
+        //given
+        String email = "test@email.com";
+        KakaoToken kakaoToken = mock(KakaoToken.class);
+
+        when(kakaoTokenRepository.findByMemberEmail(email)).thenReturn(Optional.of(kakaoToken));
+        when(kakaoToken.isAccessTokenExpired()).thenReturn(true);
+        when(kakaoToken.isRefreshTokenExpired()).thenReturn(true);
+
+        //when, then
+        assertThrows(InvalidJwtException.class, () -> kakaoTokenService.getValidAccessTokenInServer(email));
+    }
+}

--- a/src/test/java/com/example/sinitto/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/TokenServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.sinitto.auth.service;
+import com.example.sinitto.common.exception.InvalidJwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@MockitoSettings
+public class TokenServiceTest {
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private TokenService tokenService;
+
+    String key = "thisistestkeynotrealkeythisistestkeynotrealkey";
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        String secretKey = Base64.getEncoder().encodeToString(this.key.getBytes());
+        tokenService = new TokenService(secretKey, redisTemplate);
+    }
+
+    @Test
+    @DisplayName("generateAccessToken 메소드 테스트 - extractEmail 메소드도 함께 사용")
+    void generateAccessTokenTest() {
+        //given
+        String email = "test@email.com";
+
+        //when
+        String token = tokenService.generateAccessToken(email);
+        String resultEmail = tokenService.extractEmail(token);
+
+        //then
+        assertNotNull(token);
+        assertTrue(token.startsWith("ey"));
+        assertEquals(email, resultEmail);
+    }
+
+    @Test
+    @DisplayName("generateRefreshToken 메소드 테스트 - extractEmail 메소드도 함께 사용")
+    void generateRefreshTokenTest(){
+        //given
+        String email = "test@email.com";
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        //when
+        String token = tokenService.generateRefreshToken(email);
+        String resultEmail = tokenService.extractEmail(token);
+
+        //then
+        assertNotNull(token);
+        assertTrue(token.startsWith("ey"));
+        assertEquals(email, resultEmail);
+    }
+}

--- a/src/test/java/com/example/sinitto/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/TokenServiceTest.java
@@ -1,4 +1,5 @@
 package com.example.sinitto.auth.service;
+
 import com.example.sinitto.common.exception.InvalidJwtException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,7 +56,7 @@ public class TokenServiceTest {
 
     @Test
     @DisplayName("generateRefreshToken 메소드 테스트 - extractEmail 메소드도 함께 사용")
-    void generateRefreshTokenTest(){
+    void generateRefreshTokenTest() {
         //given
         String email = "test@email.com";
 

--- a/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
+++ b/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
@@ -34,7 +34,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("readGuide 메소드 테스트")
-    void readGuardTest(){
+    void readGuardTest() {
         //given
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
         Long memberId = 1L;
@@ -53,7 +53,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("updateGuard 메소드 테스트")
-    void updateGuardTest(){
+    void updateGuardTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -66,12 +66,12 @@ public class GuardServiceTest {
         guardService.updateGuard(memberId, guardRequest);
 
         //then
-        verify(member,times(1)).updateMember(guardRequest.name(), guardRequest.phoneNumber());
+        verify(member, times(1)).updateMember(guardRequest.name(), guardRequest.phoneNumber());
     }
 
     @Test
     @DisplayName("deleteGuard 메소드 테스트")
-    void deleteGuardTest(){
+    void deleteGuardTest() {
         // Given
         Long memberId = 1L;
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
@@ -86,7 +86,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("createSenior 메소드 테스트")
-    void createSeniorTest(){
+    void createSeniorTest() {
         // Given
         Long memberId = 1L;
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
@@ -95,7 +95,7 @@ public class GuardServiceTest {
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(seniorRepository.save(any(Senior.class))).thenReturn(senior);
         // When
-         guardService.createSenior(memberId, seniorRequest);
+        guardService.createSenior(memberId, seniorRequest);
 
         // Then
         verify(seniorRepository, times(1)).save(any(Senior.class));
@@ -103,7 +103,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("createSenior 테스트 - 시니또일 경우 BadRequestException 발생")
-    void createSeniorTestWhenSinittoDoThis(){
+    void createSeniorTestWhenSinittoDoThis() {
         // Given
         Long memberId = 1L;
         Member member = new Member("testName", "01012345678", "test@mail.com", true);
@@ -117,7 +117,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("readSeniors 메소드 테스트")
-    void readSeniorsTest(){
+    void readSeniorsTest() {
         //given
         Long memberId = 1L;
         Member member = new Member("testName", "01012345678", "test@mail.com", true);
@@ -143,7 +143,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("readOneSenior 메소드 테스트")
-    void readOneSeniorTest(){
+    void readOneSeniorTest() {
         //given
         Long memberId = 1L;
         Long seniorId = 2L;
@@ -161,7 +161,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("updateSenior 메소드 테스트")
-    void updateSeniorTest(){
+    void updateSeniorTest() {
         //given
         Long memberId = 1L;
         Long seniorId = 2L;
@@ -179,7 +179,7 @@ public class GuardServiceTest {
 
     @Test
     @DisplayName("deleteSenior 메소드 테스트")
-    void deleteSeniorTest(){
+    void deleteSeniorTest() {
         //given
         Long memberId = 1L;
         Long seniorId = 2L;

--- a/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
+++ b/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
@@ -1,0 +1,200 @@
+package com.example.sinitto.guard.service;
+
+import com.example.sinitto.common.exception.BadRequestException;
+import com.example.sinitto.guard.dto.GuardRequest;
+import com.example.sinitto.guard.dto.GuardResponse;
+import com.example.sinitto.guard.dto.SeniorRequest;
+import com.example.sinitto.guard.dto.SeniorResponse;
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class GuardServiceTest {
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    SeniorRepository seniorRepository;
+    @InjectMocks
+    GuardService guardService;
+
+    @Test
+    @DisplayName("readGuide 메소드 테스트")
+    void readGuardTest(){
+        //given
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Long memberId = 1L;
+        Optional<Member> memberOptional = Optional.of(member);
+        GuardResponse response = new GuardResponse(member.getName(), member.getEmail(), member.getPhoneNumber());
+        when(memberRepository.findById(memberId)).thenReturn(memberOptional);
+
+        //when
+        GuardResponse result = guardService.readGuard(memberId);
+
+        //then
+        assertEquals(member.getName(), result.name());
+        assertEquals(member.getEmail(), result.email());
+        assertEquals(member.getPhoneNumber(), result.phoneNumber());
+    }
+
+    @Test
+    @DisplayName("updateGuard 메소드 테스트")
+    void updateGuardTest(){
+        //given
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Long memberId = 1L;
+        Optional<Member> memberOptional = Optional.of(member);
+        GuardRequest guardRequest = new GuardRequest("newTestName", "01087654321");
+
+        when(memberRepository.findById(memberId)).thenReturn(memberOptional);
+
+        //when
+        Member updatedMember = guardService.updateGuard(memberId, guardRequest);
+
+        //then
+        assertEquals(updatedMember.getName(), guardRequest.name());
+        assertEquals(updatedMember.getPhoneNumber(), guardRequest.phoneNumber());
+    }
+
+    @Test
+    @DisplayName("deleteGuard 메소드 테스트")
+    void deleteGuardTest(){
+        // Given
+        Long memberId = 1L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // When
+        guardService.deleteGuard(memberId);
+
+        // Then
+        verify(memberRepository, times(1)).delete(member);
+    }
+
+    @Test
+    @DisplayName("createSenior 메소드 테스트")
+    void createSeniorTest(){
+        // Given
+        Long memberId = 1L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        SeniorRequest seniorRequest = new SeniorRequest("testSeniorName", "01011111111");
+        Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(seniorRepository.save(any(Senior.class))).thenReturn(senior);
+        // When
+        Senior result = guardService.createSenior(memberId, seniorRequest);
+
+        // Then
+        assertEquals(senior.getName(), result.getName());
+        assertEquals(senior.getPhoneNumber(), result.getPhoneNumber());
+        assertEquals(senior.getMember(), result.getMember());
+    }
+
+    @Test
+    @DisplayName("createSenior 테스트 - 시니또일 경우 BadRequestException 발생")
+    void createSeniorTestWhenSinittoDoThis(){
+        // Given
+        Long memberId = 1L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", true);
+        SeniorRequest seniorRequest = new SeniorRequest("testSeniorName", "01011111111");
+        Senior senior = new Senior(seniorRequest.seniorName(), seniorRequest.seniorPhoneNumber(), member);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // When, Then
+        assertThrows(BadRequestException.class, () -> guardService.createSenior(memberId, seniorRequest));
+    }
+
+    @Test
+    @DisplayName("readSeniors 메소드 테스트")
+    void readSeniorsTest(){
+        //given
+        Long memberId = 1L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", true);
+
+        List<Senior> seniorList = new ArrayList<>();
+        seniorList.add(new Senior("testSenior1", "01011111111", member));
+        seniorList.add(new Senior("testSenior2", "01022222222", member));
+        seniorList.add(new Senior("testSenior3", "01033333333", member));
+
+        when(seniorRepository.findByMemberId(memberId)).thenReturn(seniorList);
+
+        //when
+        List<SeniorResponse> result = guardService.readSeniors(memberId);
+
+        //then
+        assertEquals(result.getFirst().seniorName(), seniorList.getFirst().getName());
+        assertEquals(result.getFirst().seniorPhoneNumber(), seniorList.getFirst().getPhoneNumber());
+        assertEquals(result.get(1).seniorName(), seniorList.get(1).getName());
+        assertEquals(result.get(1).seniorPhoneNumber(), seniorList.get(1).getPhoneNumber());
+        assertEquals(result.get(2).seniorName(), seniorList.get(2).getName());
+        assertEquals(result.get(2).seniorPhoneNumber(), seniorList.get(2).getPhoneNumber());
+    }
+
+    @Test
+    @DisplayName("readOneSenior 메소드 테스트")
+    void readOneSeniorTest(){
+        //given
+        Long memberId = 1L;
+        Long seniorId = 2L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", true);
+        Senior senior = new Senior("testSeniorName", "01000000000", member);
+
+        when(seniorRepository.findByIdAndMemberId(seniorId, memberId)).thenReturn(Optional.of(senior));
+        //when
+        SeniorResponse result = guardService.readOneSenior(memberId, seniorId);
+
+        //then
+        assertEquals(result.seniorName(), senior.getName());
+        assertEquals(result.seniorPhoneNumber(), senior.getPhoneNumber());
+    }
+
+    @Test
+    @DisplayName("updateSenior 메소드 테스트")
+    void updateSeniorTest(){
+        //given
+        Long memberId = 1L;
+        Long seniorId = 2L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", true);
+        Senior senior = new Senior("testSeniorName", "01000000000", member);
+        SeniorRequest request = new SeniorRequest("newSeniorName", "01011111111");
+
+        when(seniorRepository.findByIdAndMemberId(seniorId, memberId)).thenReturn(Optional.of(senior));
+        //when
+        Senior result = guardService.updateSenior(memberId, seniorId, request);
+
+        //then
+        assertEquals(result.getName(), request.seniorName());
+        assertEquals(result.getPhoneNumber(), request.seniorPhoneNumber());
+    }
+
+    @Test
+    @DisplayName("deleteSenior 메소드 테스트")
+    void deleteSeniorTest(){
+        //given
+        Long memberId = 1L;
+        Long seniorId = 2L;
+        Member member = new Member("testName", "01012345678", "test@mail.com", true);
+        Senior senior = new Senior("testSeniorName", "01000000000", member);
+
+        when(seniorRepository.findByIdAndMemberId(seniorId, memberId)).thenReturn(Optional.of(senior));
+        //when
+        guardService.deleteSenior(memberId, seniorId);
+
+        //then
+        verify(seniorRepository, times(1)).delete(senior);
+    }
+}

--- a/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
+++ b/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
@@ -55,7 +55,7 @@ public class GuardServiceTest {
     @DisplayName("updateGuard 메소드 테스트")
     void updateGuardTest(){
         //given
-        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Member member = mock(Member.class);
         Long memberId = 1L;
         Optional<Member> memberOptional = Optional.of(member);
         GuardRequest guardRequest = new GuardRequest("newTestName", "01087654321");
@@ -63,11 +63,10 @@ public class GuardServiceTest {
         when(memberRepository.findById(memberId)).thenReturn(memberOptional);
 
         //when
-        Member updatedMember = guardService.updateGuard(memberId, guardRequest);
+        guardService.updateGuard(memberId, guardRequest);
 
         //then
-        assertEquals(updatedMember.getName(), guardRequest.name());
-        assertEquals(updatedMember.getPhoneNumber(), guardRequest.phoneNumber());
+        verify(member,times(1)).updateMember(guardRequest.name(), guardRequest.phoneNumber());
     }
 
     @Test
@@ -96,12 +95,10 @@ public class GuardServiceTest {
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(seniorRepository.save(any(Senior.class))).thenReturn(senior);
         // When
-        Senior result = guardService.createSenior(memberId, seniorRequest);
+         guardService.createSenior(memberId, seniorRequest);
 
         // Then
-        assertEquals(senior.getName(), result.getName());
-        assertEquals(senior.getPhoneNumber(), result.getPhoneNumber());
-        assertEquals(senior.getMember(), result.getMember());
+        verify(seniorRepository, times(1)).save(any(Senior.class));
     }
 
     @Test
@@ -169,16 +166,15 @@ public class GuardServiceTest {
         Long memberId = 1L;
         Long seniorId = 2L;
         Member member = new Member("testName", "01012345678", "test@mail.com", true);
-        Senior senior = new Senior("testSeniorName", "01000000000", member);
+        Senior senior = mock(Senior.class);
         SeniorRequest request = new SeniorRequest("newSeniorName", "01011111111");
 
         when(seniorRepository.findByIdAndMemberId(seniorId, memberId)).thenReturn(Optional.of(senior));
         //when
-        Senior result = guardService.updateSenior(memberId, seniorId, request);
+        guardService.updateSenior(memberId, seniorId, request);
 
         //then
-        assertEquals(result.getName(), request.seniorName());
-        assertEquals(result.getPhoneNumber(), request.seniorPhoneNumber());
+        verify(senior, times(1)).updateSenior(request.seniorName(), request.seniorPhoneNumber());
     }
 
     @Test

--- a/src/test/java/com/example/sinitto/guardGuideline/service/GuardGuildelineServiceTest.java
+++ b/src/test/java/com/example/sinitto/guardGuideline/service/GuardGuildelineServiceTest.java
@@ -36,7 +36,7 @@ public class GuardGuildelineServiceTest {
 
     @Test
     @DisplayName("addGuardGuideline 메소드 테스트")
-    void addGuardGuidelineTest(){
+    void addGuardGuidelineTest() {
         //given
         Member member = new Member("testName", "01000000000", "test@mail.com", false);
         Long memberId = 1L;
@@ -56,7 +56,7 @@ public class GuardGuildelineServiceTest {
 
     @Test
     @DisplayName("readAllGuardGuidelinesByCategoryAndSenior 메소드 테스트")
-    void readAllGuardGuidelinesByCategoryAndSeniorTest(){
+    void readAllGuardGuidelinesByCategoryAndSeniorTest() {
         //given
         Long memberId = 1L;
         Senior senior = mock(Senior.class);
@@ -80,7 +80,7 @@ public class GuardGuildelineServiceTest {
 
     @Test
     @DisplayName("readAllGuardGuidelinesByCategoryAndCallback 메소드 테스트")
-    void readAllGuardGuidelinesByCategoryAndCallbackTest(){
+    void readAllGuardGuidelinesByCategoryAndCallbackTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -109,7 +109,7 @@ public class GuardGuildelineServiceTest {
 
     @Test
     @DisplayName("updateGuardGuideline 메소드 테스트")
-    void updateGuardGuidelineTest(){
+    void updateGuardGuidelineTest() {
         //given
         Long memberId = 1L;
         Senior senior = mock(Senior.class);
@@ -129,7 +129,7 @@ public class GuardGuildelineServiceTest {
 
     @Test
     @DisplayName("deleteGuardGuideline 메소드 테스트")
-    void deleteGuardGuidelineTest(){
+    void deleteGuardGuidelineTest() {
         //given
         Senior senior = mock(Senior.class);
         Long memberId = 1L;
@@ -147,7 +147,7 @@ public class GuardGuildelineServiceTest {
 
     @Test
     @DisplayName("readAllGuardGuidelinesBySenior 메소드 테스트")
-    void readAllGuardGuidelinesBySeniorTest(){
+    void readAllGuardGuidelinesBySeniorTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;

--- a/src/test/java/com/example/sinitto/guardGuideline/service/GuardGuildelineServiceTest.java
+++ b/src/test/java/com/example/sinitto/guardGuideline/service/GuardGuildelineServiceTest.java
@@ -1,0 +1,171 @@
+package com.example.sinitto.guardGuideline.service;
+
+import com.example.sinitto.callback.entity.Callback;
+import com.example.sinitto.callback.repository.CallbackRepository;
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.guardGuideline.dto.GuardGuidelineRequest;
+import com.example.sinitto.guardGuideline.dto.GuardGuidelineResponse;
+import com.example.sinitto.guardGuideline.entity.GuardGuideline;
+import com.example.sinitto.guardGuideline.repository.GuardGuidelineRepository;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class GuardGuildelineServiceTest {
+    @Mock
+    GuardGuidelineRepository guardGuidelineRepository;
+    @Mock
+    SeniorRepository seniorRepository;
+    @Mock
+    CallbackRepository callbackRepository;
+    @InjectMocks
+    GuardGuidelineService guardGuidelineService;
+
+    @Test
+    @DisplayName("addGuardGuideline 메소드 테스트")
+    void addGuardGuidelineTest(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@mail.com", false);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        Long seniorId = 2L;
+        GuardGuidelineRequest guardGuidelineRequest = new GuardGuidelineRequest
+                (seniorId, GuardGuideline.Type.TAXI, "testTitle", "testContent");
+        when(seniorRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+
+        //when
+        guardGuidelineService.addGuardGuideline(memberId, guardGuidelineRequest);
+
+        //then
+        verify(senior, times(1)).isNotGuard(memberId);
+        verify(guardGuidelineRepository, times(1)).save(any(GuardGuideline.class));
+    }
+
+    @Test
+    @DisplayName("readAllGuardGuidelinesByCategoryAndSenior 메소드 테스트")
+    void readAllGuardGuidelinesByCategoryAndSeniorTest(){
+        //given
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        Long seniorId = 2L;
+        GuardGuideline.Type type = GuardGuideline.Type.TAXI;
+        List<GuardGuideline> guardGuidelines = new ArrayList<>();
+        guardGuidelines.add(new GuardGuideline(GuardGuideline.Type.TAXI, "testTitle", "testContent", senior));
+
+        when(guardGuidelineRepository.findBySeniorIdAndType(seniorId, type)).thenReturn(guardGuidelines);
+        when(seniorRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+
+        //when
+        List<GuardGuidelineResponse> result = guardGuidelineService.readAllGuardGuidelinesByCategoryAndSenior(memberId, seniorId, type);
+
+        //then
+        verify(senior, times(1)).isNotGuard(memberId);
+        assertEquals(guardGuidelines.getFirst().getType(), result.getFirst().type());
+        assertEquals(guardGuidelines.getFirst().getTitle(), result.getFirst().title());
+        assertEquals(guardGuidelines.getFirst().getContent(), result.getFirst().content());
+    }
+
+    @Test
+    @DisplayName("readAllGuardGuidelinesByCategoryAndCallback 메소드 테스트")
+    void readAllGuardGuidelinesByCategoryAndCallbackTest(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        Long seniorId = 2L;
+        Callback callback = mock(Callback.class);
+        Long callbackId = 3L;
+        GuardGuideline.Type type = GuardGuideline.Type.TAXI;
+        List<GuardGuideline> guardGuidelines = new ArrayList<>();
+        guardGuidelines.add(new GuardGuideline(GuardGuideline.Type.TAXI, "testTitle", "testContent", senior));
+
+        // when(callback.getAssignedMemberId()).thenReturn(memberId); <- 분명 이거도 쓰는데... 왜 없애니까 되지...?
+        when(callback.getStatus()).thenReturn(Callback.Status.WAITING.name());
+        when(callback.getSeniorId()).thenReturn(seniorId);
+        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+        when(guardGuidelineRepository.findBySeniorIdAndType(seniorId, type)).thenReturn(guardGuidelines);
+
+        //when
+        List<GuardGuidelineResponse> result = guardGuidelineService.readAllGuardGuidelinesByCategoryAndCallback(memberId, callbackId, type);
+
+        //then
+        assertEquals(result.getFirst().type(), guardGuidelines.getFirst().getType());
+        assertEquals(result.getFirst().title(), guardGuidelines.getFirst().getTitle());
+        assertEquals(result.getFirst().content(), guardGuidelines.getFirst().getContent());
+    }
+
+    @Test
+    @DisplayName("updateGuardGuideline 메소드 테스트")
+    void updateGuardGuidelineTest(){
+        //given
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        GuardGuideline guardGuideline = mock(GuardGuideline.class);
+        Long guidelineId = 2L;
+        GuardGuidelineRequest guardGuidelineRequest = mock(GuardGuidelineRequest.class);
+
+        when(guardGuidelineRepository.findById(guidelineId)).thenReturn(Optional.of(guardGuideline));
+        when(seniorRepository.findById(guardGuidelineRequest.seniorId())).thenReturn(Optional.of(senior));
+        //when
+        guardGuidelineService.updateGuardGuideline(memberId, guidelineId, guardGuidelineRequest);
+
+        //then
+        verify(senior, times(1)).isNotGuard(memberId);
+        verify(guardGuideline, times(1)).updateGuardGuideline(guardGuidelineRequest.type(), guardGuidelineRequest.title(), guardGuidelineRequest.content());
+    }
+
+    @Test
+    @DisplayName("deleteGuardGuideline 메소드 테스트")
+    void deleteGuardGuidelineTest(){
+        //given
+        Senior senior = mock(Senior.class);
+        Long memberId = 1L;
+        GuardGuideline guardGuideline = new GuardGuideline(GuardGuideline.Type.TAXI, "testTitle", "testContent", senior);
+        Long guidelineId = 2L;
+
+        when(senior.isNotGuard(memberId)).thenReturn(false);
+        when(guardGuidelineRepository.findById(guidelineId)).thenReturn(Optional.of(guardGuideline));
+        //when
+        guardGuidelineService.deleteGuardGuideline(memberId, guidelineId);
+
+        //then
+        verify(guardGuidelineRepository, times(1)).delete(any(GuardGuideline.class));
+    }
+
+    @Test
+    @DisplayName("readAllGuardGuidelinesBySenior 메소드 테스트")
+    void readAllGuardGuidelinesBySeniorTest(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        Long seniorId = 2L;
+        List<GuardGuideline> guardGuidelines = new ArrayList<>();
+        guardGuidelines.add(mock(GuardGuideline.class));
+
+        when(seniorRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(senior.isNotGuard(memberId)).thenReturn(false);
+        when(guardGuidelineRepository.findBySeniorId(seniorId)).thenReturn(guardGuidelines);
+
+        //when
+        List<GuardGuidelineResponse> result = guardGuidelineService.readAllGuardGuidelinesBySenior(memberId, seniorId);
+
+        //then
+        assertEquals(result.getFirst().type(), guardGuidelines.getFirst().getType());
+        assertEquals(result.getFirst().title(), guardGuidelines.getFirst().getTitle());
+        assertEquals(result.getFirst().content(), guardGuidelines.getFirst().getContent());
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
@@ -1,0 +1,1004 @@
+package com.example.sinitto.hellocall.service;
+
+import com.example.sinitto.common.exception.BadRequestException;
+import com.example.sinitto.common.exception.ConflictException;
+import com.example.sinitto.common.exception.NotFoundException;
+import com.example.sinitto.common.exception.UnauthorizedException;
+import com.example.sinitto.guard.repository.SeniorRepository;
+import com.example.sinitto.helloCall.dto.*;
+import com.example.sinitto.helloCall.entity.HelloCall;
+import com.example.sinitto.helloCall.entity.HelloCallTimeLog;
+import com.example.sinitto.helloCall.entity.TimeSlot;
+import com.example.sinitto.helloCall.repository.HelloCallRepository;
+import com.example.sinitto.helloCall.repository.HelloCallTimeLogRepository;
+import com.example.sinitto.helloCall.repository.TimeSlotRepository;
+import com.example.sinitto.helloCall.service.HelloCallService;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.entity.Senior;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.entity.PointLog;
+import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class HelloCallServiceTest {
+    @Mock
+    HelloCallRepository helloCallRepository;
+    @Mock
+    TimeSlotRepository timeSlotRepository;
+    @Mock
+    SeniorRepository seniorRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    HelloCallTimeLogRepository helloCallTimeLogRepository;
+    @Mock
+    PointRepository pointRepository;
+    @Mock
+    PointLogRepository pointLogRepository;
+    @InjectMocks
+    HelloCallService helloCallService;
+
+    @Test
+    @DisplayName("createHelloCallByGuard 메소드 테스트")
+    void createHelloCallByGuard(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
+        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
+        String dayName = "";
+
+        switch (dayOfWeek){
+            case DayOfWeek.MONDAY -> dayName="월";
+            case DayOfWeek.TUESDAY -> dayName="화";
+            case DayOfWeek.WEDNESDAY -> dayName="수";
+            case DayOfWeek.THURSDAY -> dayName="목";
+            case DayOfWeek.FRIDAY -> dayName="금";
+            case DayOfWeek.SATURDAY -> dayName="토";
+            case DayOfWeek.SUNDAY -> dayName="일";
+        }
+        timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now().plusHours(1), LocalTime.now().plusHours(1)));
+        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(10), timeSlots, 1000, 10, "testRequirement");
+        Point point = new Point(2000, member);
+
+        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
+        when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
+        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.of(point));
+
+        //when
+        helloCallService.createHelloCallByGuard(memberId, helloCallRequest);
+
+        //then
+        verify(helloCallRepository, times(1)).save(any(HelloCall.class));
+        verify(timeSlotRepository, times(helloCallRequest.timeSlots().size())).save(any(TimeSlot.class));
+        verify(pointLogRepository, times(1)).save(any(PointLog.class));
+    }
+
+    @Test
+    @DisplayName("createHelloCallByGuard 메소드 테스트 - 시니어를 찾을 수 없을 때")
+    void createHelloCallByGuardWhenSeniorIsNull(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
+        timeSlots.add(new HelloCallRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
+        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+
+        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
+    }
+
+    @Test
+    @DisplayName("createHelloCallByGuard 메소드 테스트 - 안부 전화 서비스가 존재할 때")
+    void createHelloCallByGuardWhenHelloCallAlreadyExists(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
+        timeSlots.add(new HelloCallRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
+        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+        Point point = new Point(2000, member);
+
+        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
+        when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(true);
+
+        //when, /then
+        assertThrows(ConflictException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
+    }
+
+    @Test
+    @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 조회 실패할 때")
+    void createHelloCallByGuardWhenPointIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
+
+        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
+        String dayName = "";
+
+        switch (dayOfWeek){
+            case DayOfWeek.MONDAY -> dayName="월";
+            case DayOfWeek.TUESDAY -> dayName="화";
+            case DayOfWeek.WEDNESDAY -> dayName="수";
+            case DayOfWeek.THURSDAY -> dayName="목";
+            case DayOfWeek.FRIDAY -> dayName="금";
+            case DayOfWeek.SATURDAY -> dayName="토";
+            case DayOfWeek.SUNDAY -> dayName="일";
+        }
+
+        timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now().plusHours(2), LocalTime.now().plusHours(4)));
+        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+
+        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
+        when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
+        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
+    }
+
+    @Test
+    @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 부족할 때")
+    void createHelloCallByGuardWhenPointIsLessThanPrice(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = mock(Senior.class);
+        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
+        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
+        String dayName = "";
+
+        switch (dayOfWeek){
+            case DayOfWeek.MONDAY -> dayName="월";
+            case DayOfWeek.TUESDAY -> dayName="화";
+            case DayOfWeek.WEDNESDAY -> dayName="수";
+            case DayOfWeek.THURSDAY -> dayName="목";
+            case DayOfWeek.FRIDAY -> dayName="금";
+            case DayOfWeek.SATURDAY -> dayName="토";
+            case DayOfWeek.SUNDAY -> dayName="일";
+        }
+        timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now(), LocalTime.now().plusHours(2)));
+        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+        Point point = new Point(100, member);
+
+        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
+        when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
+        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.of(point));
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
+    }
+
+    @Test
+    @DisplayName("readAllHelloCallsByGuard 메소드 테스트")
+    void readAllHelloCallsByGuardTest(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        List<Senior> seniors = new ArrayList<>();
+        seniors.add(new Senior("testName", "01000000000", member));
+        List<HelloCall> helloCalls = new ArrayList<>();
+        helloCalls.add(new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 1000, 10, "testRequirement", seniors.getFirst()));
+
+        when(seniorRepository.findByMemberId(memberId)).thenReturn(seniors);
+        when(helloCallRepository.findAllBySeniorIn(seniors)).thenReturn(helloCalls);
+
+        //when
+        List<HelloCallResponse> result = helloCallService.readAllHelloCallsByGuard(memberId);
+
+        //then
+        assertEquals(result.getFirst().seniorName(), seniors.getFirst().getName());
+    }
+
+    @Test
+    @DisplayName("readAllWaitingHelloCallsBySinitto 메소드 테스트")
+    void readAllWaitingHelloCallsBySinitto(){
+        //given
+        Pageable pageable = PageRequest.of(0, 10);
+        Senior senior = mock(Senior.class);
+        List<HelloCall> helloCalls = new ArrayList<>();
+        helloCalls.add(new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior));
+
+        when(helloCallRepository.findAll()).thenReturn(helloCalls);
+
+        //when
+        Page<HelloCallResponse> result = helloCallService.readAllWaitingHelloCallsBySinitto(pageable);
+
+        //then
+        assertEquals(helloCalls.getFirst().getSenior().getName(), result.getContent().getFirst().seniorName());
+        assertEquals(HelloCall.Status.WAITING, result.getContent().getFirst().status());
+    }
+
+    @Test
+    @DisplayName("readHelloCallDetail 메소드 테스트")
+    void readHelloCallDetail(){
+        //given
+        Senior senior = mock(Senior.class);
+        Long helloCallId = 1L;
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+
+        //when
+        HelloCallDetailResponse result = helloCallService.readHelloCallDetail(helloCallId);
+
+        //then
+        assertEquals(result.seniorName(), senior.getName());
+        assertEquals(result.seniorPhoneNumber(), senior.getPhoneNumber());
+        assertEquals(result.startDate(), helloCall.getStartDate());
+        assertEquals(result.endDate(), helloCall.getEndDate());
+        assertEquals(result.requirement(), helloCall.getRequirement());
+        assertEquals(result.price(), helloCall.getPrice());
+    }
+
+    @Test
+    @DisplayName("readHelloCallDetail 메소드 테스트 - HelloCall을 찾을 수 없을 때")
+    void readHelloCallDetailWhenHelloCallIsNotExist(){
+        //given
+        Long helloCallId = 1L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.readHelloCallDetail(helloCallId));
+    }
+
+    @Test
+    @DisplayName("updateHelloCallByGuard 메소드 테스트 - HelloCall이 없을 때")
+    void updateHelloCallByGuardTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+        List<HelloCallDetailUpdateRequest.TimeSlot> timeSlots = new ArrayList<>();
+        timeSlots.add(new HelloCallDetailUpdateRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
+        HelloCallDetailUpdateRequest helloCallDetailUpdateRequest = new HelloCallDetailUpdateRequest( LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.updateHelloCallByGuard(memberId, helloCallId, helloCallDetailUpdateRequest));
+    }
+
+    @Test
+    @DisplayName("updateHelloCallByGuard 메소드 테스트 - member가 없을 때")
+    void updateHelloCallByGuardTestWhenMemberIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        Long helloCallId = 2L;
+        List<HelloCallDetailUpdateRequest.TimeSlot> timeSlots = new ArrayList<>();
+        timeSlots.add(new HelloCallDetailUpdateRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
+        HelloCallDetailUpdateRequest helloCallDetailUpdateRequest = new HelloCallDetailUpdateRequest( LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.updateHelloCallByGuard(memberId, helloCallId, helloCallDetailUpdateRequest));
+    }
+
+    @Test
+    @DisplayName("deleteHellCallByGuard 메소드 테스트")
+    void deleteHellCallByGuardTest(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        Point point = new Point(1000, member);
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.of(point));
+
+        //when
+        helloCallService.deleteHellCallByGuard(memberId, helloCallId);
+
+        //then
+        verify(pointLogRepository, times(1)).save(any(PointLog.class));
+        verify(helloCallRepository, times(1)).delete(any(HelloCall.class));
+    }
+
+    @Test
+    @DisplayName("deleteHellCallByGuard 메소드 테스트 - HelloCall을 조회할 수 없을 때")
+    void deleteHellCallByGuardTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.deleteHellCallByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("deleteHellCallByGuard 메소드 테스트 - 멤버를 조회할 수 없을 때")
+    void deleteHellCallByGuardTestWhenMemberIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.deleteHellCallByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("deleteHellCallByGuard 메소드 테스트 - 포인트를 조회할 수 없을 때")
+    void deleteHellCallByGuardTestWhenPointIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.deleteHellCallByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("readHelloCallTimeLogByGuard 메소드 테스트")
+    void readHelloCallTimeLogByGuardTest(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        List<HelloCallTimeLog> helloCallTimeLogs = new ArrayList<>();
+        helloCallTimeLogs.add(mock(HelloCallTimeLog.class));
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallTimeLogRepository.findAllByHelloCallId(helloCallId)).thenReturn(helloCallTimeLogs);
+
+        //when
+        List<HelloCallTimeLogResponse> result = helloCallService.readHelloCallTimeLogByGuard(memberId, helloCallId);
+
+        //then
+        assertEquals(result.getFirst().startTime(), helloCallTimeLogs.getFirst().getStartDateAndTime());
+        assertEquals(result.getFirst().endTime(), helloCallTimeLogs.getFirst().getEndDateAndTime());
+    }
+
+    @Test
+    @DisplayName("readHelloCallTimeLogByGuard 메소드 테스트 - HelloCall을 찾을 수 없을 때")
+    void readHelloCallTimeLogByGuardTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.readHelloCallTimeLogByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("readHelloCallTimeLogByGuard 메소드 테스트 - Member를 찾을 수 없을 때")
+    void readHelloCallTimeLogByGuardTestWhenMemberIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.readHelloCallTimeLogByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("readHelloCallReportByGuard 메소드 테스트")
+    void readHelloCallReportByGuardTest(){
+        //given
+        Member member = mock(Member.class);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        helloCall.setReport("testReport");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+
+        //when
+        HelloCallReportResponse result = helloCallService.readHelloCallReportByGuard(memberId, helloCallId);
+
+        //then
+        assertEquals(result.startDate(), helloCall.getStartDate());
+        assertEquals(result.endDate(), helloCall.getEndDate());
+        assertEquals(result.sinittoName(), helloCall.getMemberName());
+        assertEquals(result.report(), helloCall.getReport());
+    }
+
+    @Test
+    @DisplayName("readHelloCallReportByGuard 메소드 테스트 - Member가 없는 경우")
+    void readHelloCallReportByGuardTestWhenMemberIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.readHelloCallReportByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("readHelloCallReportByGuard 메소드 테스트 - HelloCall이 없는 경우")
+    void readHelloCallReportByGuardTestWhenHelloCallIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        helloCall.setReport(null);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.readHelloCallReportByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("readHelloCallReportByGuard 메소드 테스트 - report가 없는 경우")
+    void readHelloCallReportByGuardTestWhenReportIsNotExist(){
+        //given
+        Member member = mock(Member.class);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        helloCall.setReport(null);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> helloCallService.readHelloCallReportByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트")
+    void makeCompleteHelloCallByGuardTest(){
+        Member member = mock(Member.class);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        helloCall.changeStatusToInProgress();
+        helloCall.changeStatusToPendingComplete();
+        Point sinittoPoint = mock(Point.class);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(pointRepository.findByMember(helloCall.getMember())).thenReturn(Optional.of(sinittoPoint));
+
+        //when
+        helloCallService.makeCompleteHelloCallByGuard(memberId, helloCallId);
+
+        // then
+        verify(pointLogRepository, times(1)).save(any(PointLog.class));
+    }
+
+    @Test
+    @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트 - Member가 없을 때")
+    void makeCompleteHelloCallByGuardTestWhenMemberIsNotWaiting(){
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.makeCompleteHelloCallByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트 - HelloCall이 없을 때")
+    void makeCompleteHelloCallByGuardTestWhenHelloCallIsNotWaiting(){
+        Member member = mock(Member.class);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.makeCompleteHelloCallByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트 - 상태가 완료 대기가 아닐 때")
+    void makeCompleteHelloCallByGuardTestWhenStatusIsNotWaiting(){
+        Member member = mock(Member.class);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> helloCallService.makeCompleteHelloCallByGuard(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("readAllHelloCallReportByAdmin 메소드 테스트")
+    void readAllHelloCallReportByAdminTest(){
+        Senior senior = mock(Senior.class);
+        Member sinitto = mock(Member.class);
+        List<HelloCall> helloCalls = new ArrayList<>();
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        helloCall.setMember(sinitto);
+        helloCall.setReport("testReport");
+        helloCalls.add(helloCall);
+
+        when(helloCallRepository.findAll()).thenReturn(helloCalls);
+
+        //when
+        List<HelloCallReportResponse> result = helloCallService.readAllHelloCallReportByAdmin();
+
+        // then
+        assertEquals(helloCalls.getFirst().getMemberName(), result.getFirst().sinittoName());
+        assertEquals(helloCalls.getFirst().getStartDate(), result.getFirst().startDate());
+        assertEquals(helloCalls.getFirst().getEndDate(), result.getFirst().endDate());
+        assertEquals(helloCalls.getFirst().getReport(), result.getFirst().report());
+        assertEquals(helloCalls.getFirst().getStatus(), HelloCall.Status.WAITING);
+    }
+
+    @Test
+    @DisplayName("acceptHelloCallBySinitto 메소드 테스트 - HelloCall이 없을 때")
+    void acceptHelloCallBySinittoTestWhenHelloCallIsNotExist(){
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.acceptHelloCallBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("acceptHelloCallBySinitto 메소드 테스트 - Member가 없을 때")
+    void acceptHelloCallBySinittoTestWhenMemberIsNotExist(){
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.acceptHelloCallBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("acceptHelloCallBySinitto 메소드 테스트 - 시니또가 아닐 때")
+    void acceptHelloCallBySinittoTestWhenMemberIsNotSinitto(){
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        //when, then
+        assertThrows(UnauthorizedException.class, () -> helloCallService.acceptHelloCallBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트")
+    void writeHelloCallStartTimeBySinittoTest(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        Optional<HelloCallTimeLog> recentLog = Optional.of(new HelloCallTimeLog(mock(HelloCall.class), sinitto, LocalDateTime.now(), LocalDateTime.now().plusDays(3)));
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+        when(helloCallTimeLogRepository.findTopByMemberAndHelloCallOrderByStartDateAndTimeDesc(sinitto, helloCall)).thenReturn(recentLog);
+
+        //when
+        helloCallService.writeHelloCallStartTimeBySinitto(memberId, helloCallId);
+
+        //then
+        verify(helloCallTimeLogRepository, times(1)).save(any(HelloCallTimeLog.class));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트 - 이미 진행중인 안부전화가 있을 때")
+    void writeHelloCallStartTimeBySinittoTestWhenHelloCallAlreadyExists(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        Optional<HelloCallTimeLog> recentLog = Optional.of(new HelloCallTimeLog(mock(HelloCall.class), sinitto, LocalDateTime.now(), null));
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+        when(helloCallTimeLogRepository.findTopByMemberAndHelloCallOrderByStartDateAndTimeDesc(sinitto, helloCall)).thenReturn(recentLog);
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> helloCallService.writeHelloCallStartTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트 - HelloCall이 없을 때")
+    void writeHelloCallStartTimeBySinittoTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.writeHelloCallStartTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트 - Member가 없을 때")
+    void writeHelloCallStartTimeBySinittoTestWhenMemberIsNotExist(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        Optional<HelloCallTimeLog> recentLog = Optional.of(new HelloCallTimeLog(mock(HelloCall.class), sinitto, LocalDateTime.now(), null));
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.writeHelloCallStartTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트")
+    void writeHelloCallEndTimeBySinittoTest(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        HelloCallTimeLog helloCallTimeLog = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.now(), null);
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+        when(helloCallTimeLogRepository.findTopByMemberAndHelloCallOrderByStartDateAndTimeDesc(sinitto, helloCall)).thenReturn(Optional.of(helloCallTimeLog));
+
+        //when
+        helloCallService.writeHelloCallEndTimeBySinitto(memberId, helloCallId);
+
+        //then
+        Duration tolerance = Duration.ofMinutes(1);
+        assertTrue(Duration.between(helloCallTimeLog.getEndDateAndTime(), LocalDateTime.now()).abs().compareTo(tolerance) <= 0);
+    }
+
+    @Test
+    @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - HelloCall이 없을 때")
+    void writeHelloCallEndTimeBySinittoTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.writeHelloCallEndTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - Member가 없을 때")
+    void writeHelloCallEndTimeBySinittoTestWhenMemberIsNotExist(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.writeHelloCallEndTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - 안부전화 로그를 찾을 수 없을 때")
+    void writeHelloCallEndTimeBySinittoTestWhenHelloCallTimeLogIsNotExist(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+        when(helloCallTimeLogRepository.findTopByMemberAndHelloCallOrderByStartDateAndTimeDesc(sinitto, helloCall)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.writeHelloCallEndTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - 이미 종료된 안부전화일 때")
+    void writeHelloCallEndTimeBySinittoTestWhenHelloCallAlreadyEnd(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        HelloCallTimeLog helloCallTimeLog = new HelloCallTimeLog(helloCall, sinitto, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+        when(helloCallTimeLogRepository.findTopByMemberAndHelloCallOrderByStartDateAndTimeDesc(sinitto, helloCall)).thenReturn(Optional.of(helloCallTimeLog));
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> helloCallService.writeHelloCallEndTimeBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("cancelHelloCallBySinitto 메소드 테스트")
+    void cancelHelloCallBySinittoTest(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        helloCall.changeStatusToInProgress();
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+
+        //when
+        helloCallService.cancelHelloCallBySinitto(memberId, helloCallId);
+
+        //then
+        assertNull(helloCall.getMember());
+        assertEquals(helloCall.getStatus(), HelloCall.Status.WAITING);
+    }
+
+    @Test
+    @DisplayName("cancelHelloCallBySinitto 메소드 테스트 - HelloCall이 없을 때")
+    void cancelHelloCallBySinittoTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.cancelHelloCallBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("cancelHelloCallBySinitto 메소드 테스트 - Member가 없을 때")
+    void cancelHelloCallBySinittoTestWhenMemberIsNotExist(){
+        //given
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        helloCall.setMember(sinitto);
+        helloCall.changeStatusToInProgress();
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.cancelHelloCallBySinitto(memberId, helloCallId));
+    }
+
+    @Test
+    @DisplayName("sendReportBySinitto 메소드 테스트")
+    void sendReportBySinittoTest(){
+        //given
+
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now().minusDays(7), LocalDate.now().minusDays(1), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        HelloCallReportRequest helloCallReportRequest = new HelloCallReportRequest(helloCallId, "testReport");
+        helloCall.setMember(sinitto);
+        helloCall.changeStatusToInProgress();
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+
+        //when
+        helloCallService.sendReportBySinitto(memberId, helloCallReportRequest);
+
+        //then
+        assertEquals(helloCall.getReport(), helloCallReportRequest.report());
+    }
+
+    @Test
+    @DisplayName("sendReportBySinitto 메소드 테스트 - HelloCall이 없을 때")
+    void sendReportBySinittoTestWhenHelloCallIsNotExist(){
+        //given
+        Long memberId = 1L;
+        Long helloCallId = 2L;
+        HelloCallReportRequest helloCallReportRequest = new HelloCallReportRequest(helloCallId, "testReport");
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.sendReportBySinitto(memberId, helloCallReportRequest));
+    }
+
+    @Test
+    @DisplayName("sendReportBySinitto 메소드 테스트 - Member가 없을 때")
+    void sendReportBySinittoTestWhenMemberIsNotExist(){
+        //given
+
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now().minusDays(7), LocalDate.now().plusDays(1), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        HelloCallReportRequest helloCallReportRequest = new HelloCallReportRequest(helloCallId, "testReport");
+        helloCall.setMember(sinitto);
+        helloCall.changeStatusToInProgress();
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.sendReportBySinitto(memberId, helloCallReportRequest));
+    }
+
+    @Test
+    @DisplayName("sendReportBySinitto 메소드 테스트 - 종료 일자보다 빠르게 종료하려 할 때")
+    void sendReportBySinittoTestWhenEndDateIsInvalid(){
+        //given
+
+        Member member = new Member("testName", "01000000000", "test@email.com", false);
+        Member sinitto = mock(Member.class);
+        Long memberId = 1L;
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        HelloCall helloCall = new HelloCall(LocalDate.now().minusDays(7), LocalDate.now().plusDays(1), 500, 10, "testRequirement", senior);
+        Long helloCallId = 2L;
+        HelloCallReportRequest helloCallReportRequest = new HelloCallReportRequest(helloCallId, "testReport");
+        helloCall.setMember(sinitto);
+        helloCall.changeStatusToInProgress();
+
+        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(sinitto));
+
+        //when, then
+        assertThrows(BadRequestException.class, () -> helloCallService.sendReportBySinitto(memberId, helloCallReportRequest));
+    }
+
+    @Test
+    @DisplayName("readOwnHelloCallBySinitto 메소드 테스트")
+    void readOwnHelloCallBySinittoTest(){
+        //given
+        Long memberId = 1L;
+        Member member = mock(Member.class);
+        Senior senior = new Senior("testSeniorName", "01012345678", member);
+        List<HelloCall> helloCalls = new ArrayList<>();
+        HelloCall helloCall = new HelloCall(LocalDate.now().minusDays(7), LocalDate.now().minusDays(3), 1000, 10, "testRequirement", senior);
+        helloCall.setMember(member);
+        helloCall.changeStatusToInProgress();
+        helloCall.changeStatusToPendingComplete();
+        helloCall.changeStatusToComplete();
+        helloCalls.add(helloCall);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(helloCallRepository.findAllByMember(member)).thenReturn(helloCalls);
+
+        //when
+        List<HelloCallResponse> result = helloCallService.readOwnHelloCallBySinitto(memberId);
+
+        //then
+        assertEquals(result.getFirst().seniorName(), helloCalls.getFirst().getSenior().getName());
+        assertEquals(result.getFirst().status(), helloCalls.getFirst().getStatus());
+    }
+
+    @Test
+    @DisplayName("readOwnHelloCallBySinitto 메소드 테스트 - Member가 없을 때")
+    void readOwnHelloCallBySinittoTestWhenMemberIsNotExist(){
+        //given
+        Long memberId = 1L;
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> helloCallService.readOwnHelloCallBySinitto(memberId));
+    }
+}

--- a/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
@@ -59,7 +59,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트")
-    void createHelloCallByGuard(){
+    void createHelloCallByGuard() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -68,14 +68,14 @@ public class HelloCallServiceTest {
         DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
         String dayName = "";
 
-        switch (dayOfWeek){
-            case DayOfWeek.MONDAY -> dayName="월";
-            case DayOfWeek.TUESDAY -> dayName="화";
-            case DayOfWeek.WEDNESDAY -> dayName="수";
-            case DayOfWeek.THURSDAY -> dayName="목";
-            case DayOfWeek.FRIDAY -> dayName="금";
-            case DayOfWeek.SATURDAY -> dayName="토";
-            case DayOfWeek.SUNDAY -> dayName="일";
+        switch (dayOfWeek) {
+            case DayOfWeek.MONDAY -> dayName = "월";
+            case DayOfWeek.TUESDAY -> dayName = "화";
+            case DayOfWeek.WEDNESDAY -> dayName = "수";
+            case DayOfWeek.THURSDAY -> dayName = "목";
+            case DayOfWeek.FRIDAY -> dayName = "금";
+            case DayOfWeek.SATURDAY -> dayName = "토";
+            case DayOfWeek.SUNDAY -> dayName = "일";
         }
         timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now().plusHours(1), LocalTime.now().plusHours(1)));
         HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(10), timeSlots, 1000, 10, "testRequirement");
@@ -96,7 +96,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 시니어를 찾을 수 없을 때")
-    void createHelloCallByGuardWhenSeniorIsNull(){
+    void createHelloCallByGuardWhenSeniorIsNull() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -113,7 +113,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 안부 전화 서비스가 존재할 때")
-    void createHelloCallByGuardWhenHelloCallAlreadyExists(){
+    void createHelloCallByGuardWhenHelloCallAlreadyExists() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -132,7 +132,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 조회 실패할 때")
-    void createHelloCallByGuardWhenPointIsNotExist(){
+    void createHelloCallByGuardWhenPointIsNotExist() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -142,14 +142,14 @@ public class HelloCallServiceTest {
         DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
         String dayName = "";
 
-        switch (dayOfWeek){
-            case DayOfWeek.MONDAY -> dayName="월";
-            case DayOfWeek.TUESDAY -> dayName="화";
-            case DayOfWeek.WEDNESDAY -> dayName="수";
-            case DayOfWeek.THURSDAY -> dayName="목";
-            case DayOfWeek.FRIDAY -> dayName="금";
-            case DayOfWeek.SATURDAY -> dayName="토";
-            case DayOfWeek.SUNDAY -> dayName="일";
+        switch (dayOfWeek) {
+            case DayOfWeek.MONDAY -> dayName = "월";
+            case DayOfWeek.TUESDAY -> dayName = "화";
+            case DayOfWeek.WEDNESDAY -> dayName = "수";
+            case DayOfWeek.THURSDAY -> dayName = "목";
+            case DayOfWeek.FRIDAY -> dayName = "금";
+            case DayOfWeek.SATURDAY -> dayName = "토";
+            case DayOfWeek.SUNDAY -> dayName = "일";
         }
 
         timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now().plusHours(2), LocalTime.now().plusHours(4)));
@@ -165,7 +165,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 부족할 때")
-    void createHelloCallByGuardWhenPointIsLessThanPrice(){
+    void createHelloCallByGuardWhenPointIsLessThanPrice() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -174,14 +174,14 @@ public class HelloCallServiceTest {
         DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
         String dayName = "";
 
-        switch (dayOfWeek){
-            case DayOfWeek.MONDAY -> dayName="월";
-            case DayOfWeek.TUESDAY -> dayName="화";
-            case DayOfWeek.WEDNESDAY -> dayName="수";
-            case DayOfWeek.THURSDAY -> dayName="목";
-            case DayOfWeek.FRIDAY -> dayName="금";
-            case DayOfWeek.SATURDAY -> dayName="토";
-            case DayOfWeek.SUNDAY -> dayName="일";
+        switch (dayOfWeek) {
+            case DayOfWeek.MONDAY -> dayName = "월";
+            case DayOfWeek.TUESDAY -> dayName = "화";
+            case DayOfWeek.WEDNESDAY -> dayName = "수";
+            case DayOfWeek.THURSDAY -> dayName = "목";
+            case DayOfWeek.FRIDAY -> dayName = "금";
+            case DayOfWeek.SATURDAY -> dayName = "토";
+            case DayOfWeek.SUNDAY -> dayName = "일";
         }
         timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now(), LocalTime.now().plusHours(2)));
         HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
@@ -197,7 +197,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readAllHelloCallsByGuard 메소드 테스트")
-    void readAllHelloCallsByGuardTest(){
+    void readAllHelloCallsByGuardTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -218,7 +218,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readAllWaitingHelloCallsBySinitto 메소드 테스트")
-    void readAllWaitingHelloCallsBySinitto(){
+    void readAllWaitingHelloCallsBySinitto() {
         //given
         Pageable pageable = PageRequest.of(0, 10);
         Senior senior = mock(Senior.class);
@@ -237,7 +237,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallDetail 메소드 테스트")
-    void readHelloCallDetail(){
+    void readHelloCallDetail() {
         //given
         Senior senior = mock(Senior.class);
         Long helloCallId = 1L;
@@ -259,7 +259,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallDetail 메소드 테스트 - HelloCall을 찾을 수 없을 때")
-    void readHelloCallDetailWhenHelloCallIsNotExist(){
+    void readHelloCallDetailWhenHelloCallIsNotExist() {
         //given
         Long helloCallId = 1L;
 
@@ -271,13 +271,13 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("updateHelloCallByGuard 메소드 테스트 - HelloCall이 없을 때")
-    void updateHelloCallByGuardTestWhenHelloCallIsNotExist(){
+    void updateHelloCallByGuardTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
         List<HelloCallDetailUpdateRequest.TimeSlot> timeSlots = new ArrayList<>();
         timeSlots.add(new HelloCallDetailUpdateRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
-        HelloCallDetailUpdateRequest helloCallDetailUpdateRequest = new HelloCallDetailUpdateRequest( LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+        HelloCallDetailUpdateRequest helloCallDetailUpdateRequest = new HelloCallDetailUpdateRequest(LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
 
         when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.empty());
 
@@ -287,7 +287,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("updateHelloCallByGuard 메소드 테스트 - member가 없을 때")
-    void updateHelloCallByGuardTestWhenMemberIsNotExist(){
+    void updateHelloCallByGuardTestWhenMemberIsNotExist() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -295,7 +295,7 @@ public class HelloCallServiceTest {
         Long helloCallId = 2L;
         List<HelloCallDetailUpdateRequest.TimeSlot> timeSlots = new ArrayList<>();
         timeSlots.add(new HelloCallDetailUpdateRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
-        HelloCallDetailUpdateRequest helloCallDetailUpdateRequest = new HelloCallDetailUpdateRequest( LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
+        HelloCallDetailUpdateRequest helloCallDetailUpdateRequest = new HelloCallDetailUpdateRequest(LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
         HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
 
         when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
@@ -307,7 +307,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("deleteHellCallByGuard 메소드 테스트")
-    void deleteHellCallByGuardTest(){
+    void deleteHellCallByGuardTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -330,7 +330,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("deleteHellCallByGuard 메소드 테스트 - HelloCall을 조회할 수 없을 때")
-    void deleteHellCallByGuardTestWhenHelloCallIsNotExist(){
+    void deleteHellCallByGuardTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -343,7 +343,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("deleteHellCallByGuard 메소드 테스트 - 멤버를 조회할 수 없을 때")
-    void deleteHellCallByGuardTestWhenMemberIsNotExist(){
+    void deleteHellCallByGuardTestWhenMemberIsNotExist() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -360,7 +360,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("deleteHellCallByGuard 메소드 테스트 - 포인트를 조회할 수 없을 때")
-    void deleteHellCallByGuardTestWhenPointIsNotExist(){
+    void deleteHellCallByGuardTestWhenPointIsNotExist() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -378,7 +378,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallTimeLogByGuard 메소드 테스트")
-    void readHelloCallTimeLogByGuardTest(){
+    void readHelloCallTimeLogByGuardTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -402,7 +402,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallTimeLogByGuard 메소드 테스트 - HelloCall을 찾을 수 없을 때")
-    void readHelloCallTimeLogByGuardTestWhenHelloCallIsNotExist(){
+    void readHelloCallTimeLogByGuardTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -415,7 +415,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallTimeLogByGuard 메소드 테스트 - Member를 찾을 수 없을 때")
-    void readHelloCallTimeLogByGuardTestWhenMemberIsNotExist(){
+    void readHelloCallTimeLogByGuardTestWhenMemberIsNotExist() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -432,7 +432,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallReportByGuard 메소드 테스트")
-    void readHelloCallReportByGuardTest(){
+    void readHelloCallReportByGuardTest() {
         //given
         Member member = mock(Member.class);
         Member sinitto = mock(Member.class);
@@ -458,7 +458,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallReportByGuard 메소드 테스트 - Member가 없는 경우")
-    void readHelloCallReportByGuardTestWhenMemberIsNotExist(){
+    void readHelloCallReportByGuardTestWhenMemberIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -471,7 +471,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallReportByGuard 메소드 테스트 - HelloCall이 없는 경우")
-    void readHelloCallReportByGuardTestWhenHelloCallIsNotExist(){
+    void readHelloCallReportByGuardTestWhenHelloCallIsNotExist() {
         //given
         Member member = mock(Member.class);
         Member sinitto = mock(Member.class);
@@ -491,7 +491,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readHelloCallReportByGuard 메소드 테스트 - report가 없는 경우")
-    void readHelloCallReportByGuardTestWhenReportIsNotExist(){
+    void readHelloCallReportByGuardTestWhenReportIsNotExist() {
         //given
         Member member = mock(Member.class);
         Member sinitto = mock(Member.class);
@@ -511,7 +511,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트")
-    void makeCompleteHelloCallByGuardTest(){
+    void makeCompleteHelloCallByGuardTest() {
         Member member = mock(Member.class);
         Member sinitto = mock(Member.class);
         Long memberId = 1L;
@@ -536,7 +536,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트 - Member가 없을 때")
-    void makeCompleteHelloCallByGuardTestWhenMemberIsNotWaiting(){
+    void makeCompleteHelloCallByGuardTestWhenMemberIsNotWaiting() {
         Long memberId = 1L;
         Long helloCallId = 2L;
 
@@ -548,7 +548,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트 - HelloCall이 없을 때")
-    void makeCompleteHelloCallByGuardTestWhenHelloCallIsNotWaiting(){
+    void makeCompleteHelloCallByGuardTestWhenHelloCallIsNotWaiting() {
         Member member = mock(Member.class);
         Member sinitto = mock(Member.class);
         Long memberId = 1L;
@@ -566,7 +566,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("makeCompleteHelloCallByGuard 메소드 테스트 - 상태가 완료 대기가 아닐 때")
-    void makeCompleteHelloCallByGuardTestWhenStatusIsNotWaiting(){
+    void makeCompleteHelloCallByGuardTestWhenStatusIsNotWaiting() {
         Member member = mock(Member.class);
         Member sinitto = mock(Member.class);
         Long memberId = 1L;
@@ -584,7 +584,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readAllHelloCallReportByAdmin 메소드 테스트")
-    void readAllHelloCallReportByAdminTest(){
+    void readAllHelloCallReportByAdminTest() {
         Senior senior = mock(Senior.class);
         Member sinitto = mock(Member.class);
         List<HelloCall> helloCalls = new ArrayList<>();
@@ -608,7 +608,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("acceptHelloCallBySinitto 메소드 테스트 - HelloCall이 없을 때")
-    void acceptHelloCallBySinittoTestWhenHelloCallIsNotExist(){
+    void acceptHelloCallBySinittoTestWhenHelloCallIsNotExist() {
         Long memberId = 1L;
         Long helloCallId = 2L;
 
@@ -620,7 +620,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("acceptHelloCallBySinitto 메소드 테스트 - Member가 없을 때")
-    void acceptHelloCallBySinittoTestWhenMemberIsNotExist(){
+    void acceptHelloCallBySinittoTestWhenMemberIsNotExist() {
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Long memberId = 1L;
         Senior senior = new Senior("testSeniorName", "01012345678", member);
@@ -636,7 +636,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("acceptHelloCallBySinitto 메소드 테스트 - 시니또가 아닐 때")
-    void acceptHelloCallBySinittoTestWhenMemberIsNotSinitto(){
+    void acceptHelloCallBySinittoTestWhenMemberIsNotSinitto() {
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Long memberId = 1L;
         Senior senior = new Senior("testSeniorName", "01012345678", member);
@@ -652,7 +652,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트")
-    void writeHelloCallStartTimeBySinittoTest(){
+    void writeHelloCallStartTimeBySinittoTest() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -676,7 +676,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트 - 이미 진행중인 안부전화가 있을 때")
-    void writeHelloCallStartTimeBySinittoTestWhenHelloCallAlreadyExists(){
+    void writeHelloCallStartTimeBySinittoTestWhenHelloCallAlreadyExists() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -697,7 +697,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트 - HelloCall이 없을 때")
-    void writeHelloCallStartTimeBySinittoTestWhenHelloCallIsNotExist(){
+    void writeHelloCallStartTimeBySinittoTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -710,7 +710,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallStartTimeBySinitto 메소드 테스트 - Member가 없을 때")
-    void writeHelloCallStartTimeBySinittoTestWhenMemberIsNotExist(){
+    void writeHelloCallStartTimeBySinittoTestWhenMemberIsNotExist() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -730,7 +730,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트")
-    void writeHelloCallEndTimeBySinittoTest(){
+    void writeHelloCallEndTimeBySinittoTest() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -755,7 +755,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - HelloCall이 없을 때")
-    void writeHelloCallEndTimeBySinittoTestWhenHelloCallIsNotExist(){
+    void writeHelloCallEndTimeBySinittoTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -768,7 +768,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - Member가 없을 때")
-    void writeHelloCallEndTimeBySinittoTestWhenMemberIsNotExist(){
+    void writeHelloCallEndTimeBySinittoTestWhenMemberIsNotExist() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Long memberId = 1L;
@@ -785,7 +785,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - 안부전화 로그를 찾을 수 없을 때")
-    void writeHelloCallEndTimeBySinittoTestWhenHelloCallTimeLogIsNotExist(){
+    void writeHelloCallEndTimeBySinittoTestWhenHelloCallTimeLogIsNotExist() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -805,7 +805,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("writeHelloCallEndTimeBySinitto 메소드 테스트 - 이미 종료된 안부전화일 때")
-    void writeHelloCallEndTimeBySinittoTestWhenHelloCallAlreadyEnd(){
+    void writeHelloCallEndTimeBySinittoTestWhenHelloCallAlreadyEnd() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -826,7 +826,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("cancelHelloCallBySinitto 메소드 테스트")
-    void cancelHelloCallBySinittoTest(){
+    void cancelHelloCallBySinittoTest() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -850,7 +850,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("cancelHelloCallBySinitto 메소드 테스트 - HelloCall이 없을 때")
-    void cancelHelloCallBySinittoTestWhenHelloCallIsNotExist(){
+    void cancelHelloCallBySinittoTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -863,7 +863,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("cancelHelloCallBySinitto 메소드 테스트 - Member가 없을 때")
-    void cancelHelloCallBySinittoTestWhenMemberIsNotExist(){
+    void cancelHelloCallBySinittoTestWhenMemberIsNotExist() {
         //given
         Member member = new Member("testName", "01000000000", "test@email.com", false);
         Member sinitto = mock(Member.class);
@@ -883,7 +883,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("sendReportBySinitto 메소드 테스트")
-    void sendReportBySinittoTest(){
+    void sendReportBySinittoTest() {
         //given
 
         Member member = new Member("testName", "01000000000", "test@email.com", false);
@@ -908,7 +908,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("sendReportBySinitto 메소드 테스트 - HelloCall이 없을 때")
-    void sendReportBySinittoTestWhenHelloCallIsNotExist(){
+    void sendReportBySinittoTestWhenHelloCallIsNotExist() {
         //given
         Long memberId = 1L;
         Long helloCallId = 2L;
@@ -922,7 +922,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("sendReportBySinitto 메소드 테스트 - Member가 없을 때")
-    void sendReportBySinittoTestWhenMemberIsNotExist(){
+    void sendReportBySinittoTestWhenMemberIsNotExist() {
         //given
 
         Member member = new Member("testName", "01000000000", "test@email.com", false);
@@ -944,7 +944,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("sendReportBySinitto 메소드 테스트 - 종료 일자보다 빠르게 종료하려 할 때")
-    void sendReportBySinittoTestWhenEndDateIsInvalid(){
+    void sendReportBySinittoTestWhenEndDateIsInvalid() {
         //given
 
         Member member = new Member("testName", "01000000000", "test@email.com", false);
@@ -966,7 +966,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readOwnHelloCallBySinitto 메소드 테스트")
-    void readOwnHelloCallBySinittoTest(){
+    void readOwnHelloCallBySinittoTest() {
         //given
         Long memberId = 1L;
         Member member = mock(Member.class);
@@ -992,7 +992,7 @@ public class HelloCallServiceTest {
 
     @Test
     @DisplayName("readOwnHelloCallBySinitto 메소드 테스트 - Member가 없을 때")
-    void readOwnHelloCallBySinittoTestWhenMemberIsNotExist(){
+    void readOwnHelloCallBySinittoTestWhenMemberIsNotExist() {
         //given
         Long memberId = 1L;
 

--- a/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
@@ -1,0 +1,145 @@
+package com.example.sinitto.member.service;
+
+import com.example.sinitto.auth.service.KakaoApiService;
+import com.example.sinitto.auth.service.KakaoTokenService;
+import com.example.sinitto.auth.service.TokenService;
+import com.example.sinitto.common.exception.ConflictException;
+import com.example.sinitto.common.exception.NotFoundException;
+import com.example.sinitto.member.dto.RegisterResponse;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.repository.PointRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class MemberServiceTest {
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    PointRepository pointRepository;
+    @Mock
+    TokenService tokenService;
+    @Mock
+    KakaoApiService kakaoApiService;
+    @Mock
+    KakaoTokenService kakaoTokenService;
+    @Mock
+    RedisTemplate<String, String> redisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    @InjectMocks
+    MemberService memberService;
+
+    @Test
+    @DisplayName("getMemberIdByToken 메소드 테스트")
+    void getMemberIdByTokenTest(){
+        //given
+        String token = "testtoken";
+        String email = "test@email.com";
+        Member member = mock(Member.class);
+
+        when(tokenService.extractEmail(token)).thenReturn(email);
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+
+        //when
+        Long result = memberService.getMemberIdByToken(token);
+
+        //then
+        assertEquals(result, member.getId());
+    }
+
+    @Test
+    @DisplayName("getMemberIdByToken 메소드 테스트 - memberRepository에 없을 경우")
+    void getMemberIdByTokenTestWhenNotInMemberRepository(){
+        //given
+        String token = "testtoken";
+        String email = "test@email.com";
+        Member member = mock(Member.class);
+
+        when(tokenService.extractEmail(token)).thenReturn(email);
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> memberService.getMemberIdByToken(token));
+    }
+
+    @Test
+    @DisplayName("registerNewMember 메소드 테스트")
+    void registerNewMemberTest(){
+        //given
+        String name = "testName";
+        String phoneNumber = "01000000000";
+        String email = "test@email.com";
+        boolean isSinitto = true;
+
+        when(memberRepository.existsByEmail(email)).thenReturn(false);
+
+        //when
+        RegisterResponse result = memberService.registerNewMember(name, phoneNumber, email, isSinitto);
+
+        //then
+        verify(memberRepository, times(1)).save(any(Member.class));
+        verify(pointRepository, times(1)).save(any(Point.class));
+        assertEquals(isSinitto, result.isSinitto());
+    }
+
+    @Test
+    @DisplayName("registerNewMember 메소드 테스트 - 이미 이메일이 있는 경우")
+    void registerNewMemberTestWhenExists(){
+        //given
+        String name = "testName";
+        String phoneNumber = "01000000000";
+        String email = "test@email.com";
+        boolean isSinitto = true;
+
+        when(memberRepository.existsByEmail(email)).thenReturn(true);
+
+        //when, then
+        assertThrows(ConflictException.class, () -> memberService.registerNewMember(name, phoneNumber, email, isSinitto));
+    }
+
+    @Test
+    @DisplayName("memberLogout 메소드 테스트")
+    void memberLogoutTest(){
+        //given
+        Long memberId = 1L;
+        Member member = mock(Member.class);
+        String storedRefreshToken = "testRefreshToken";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplate.opsForValue().get(member.getEmail())).thenReturn(storedRefreshToken);
+        //when
+        memberService.memberLogout(memberId);
+
+        //then
+        verify(redisTemplate, times(1)).delete(member.getEmail());
+    }
+
+    @Test
+    @DisplayName("memberLogout 메소드 테스트 - member를 찾을 수 없는 경우")
+    void memberLogoutTestWhenMemberIsNull(){
+        //given
+        Long memberId = 1L;
+        Member member = mock(Member.class);
+        String storedRefreshToken = "testRefreshToken";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> memberService.memberLogout(memberId));
+    }
+}

--- a/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
@@ -45,7 +45,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("getMemberIdByToken 메소드 테스트")
-    void getMemberIdByTokenTest(){
+    void getMemberIdByTokenTest() {
         //given
         String token = "testtoken";
         String email = "test@email.com";
@@ -63,7 +63,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("getMemberIdByToken 메소드 테스트 - memberRepository에 없을 경우")
-    void getMemberIdByTokenTestWhenNotInMemberRepository(){
+    void getMemberIdByTokenTestWhenNotInMemberRepository() {
         //given
         String token = "testtoken";
         String email = "test@email.com";
@@ -78,7 +78,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("registerNewMember 메소드 테스트")
-    void registerNewMemberTest(){
+    void registerNewMemberTest() {
         //given
         String name = "testName";
         String phoneNumber = "01000000000";
@@ -98,7 +98,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("registerNewMember 메소드 테스트 - 이미 이메일이 있는 경우")
-    void registerNewMemberTestWhenExists(){
+    void registerNewMemberTestWhenExists() {
         //given
         String name = "testName";
         String phoneNumber = "01000000000";
@@ -113,7 +113,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("memberLogout 메소드 테스트")
-    void memberLogoutTest(){
+    void memberLogoutTest() {
         //given
         Long memberId = 1L;
         Member member = mock(Member.class);
@@ -131,7 +131,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("memberLogout 메소드 테스트 - member를 찾을 수 없는 경우")
-    void memberLogoutTestWhenMemberIsNull(){
+    void memberLogoutTestWhenMemberIsNull() {
         //given
         Long memberId = 1L;
         Member member = mock(Member.class);

--- a/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
@@ -33,10 +33,6 @@ public class MemberServiceTest {
     @Mock
     TokenService tokenService;
     @Mock
-    KakaoApiService kakaoApiService;
-    @Mock
-    KakaoTokenService kakaoTokenService;
-    @Mock
     RedisTemplate<String, String> redisTemplate;
     @Mock
     private ValueOperations<String, String> valueOperations;

--- a/src/test/java/com/example/sinitto/sinitto/service/SinittoServiceTest.java
+++ b/src/test/java/com/example/sinitto/sinitto/service/SinittoServiceTest.java
@@ -1,0 +1,133 @@
+package com.example.sinitto.sinitto.service;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.sinitto.dto.SinittoBankRequest;
+import com.example.sinitto.sinitto.dto.SinittoBankResponse;
+import com.example.sinitto.sinitto.dto.SinittoRequest;
+import com.example.sinitto.sinitto.dto.SinittoResponse;
+import com.example.sinitto.sinitto.entity.SinittoBankInfo;
+import com.example.sinitto.sinitto.repository.SinittoBankInfoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockitoSettings
+public class SinittoServiceTest {
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    SinittoBankInfoRepository sinittoBankInfoRepository;
+    @InjectMocks
+    SinittoService sinittoService;
+
+    @Test
+    @DisplayName("createSinittoBankInfo 메소드 테스트")
+    void createSinittoBankInfoTest(){
+        //given
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Long memberId = 1L;
+        SinittoBankRequest sinittoBankRequest = new SinittoBankRequest("123456789", "testBankName");
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        //when
+        sinittoService.createSinittoBankInfo(memberId, sinittoBankRequest);
+
+        //then
+        verify(sinittoBankInfoRepository,times(1)).save(any(SinittoBankInfo.class));
+    }
+
+    @Test
+    @DisplayName("readSinitto 메소드 테스트")
+    void readSinittoTest(){
+        //given
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Long memberId = 1L;
+        SinittoBankRequest sinittoBankRequest = new SinittoBankRequest("123456789", "testBankName");
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        //when
+        SinittoResponse result = sinittoService.readSinitto(memberId);
+
+        //then
+        assertEquals(member.getName(), result.name());
+        assertEquals(member.getPhoneNumber(), result.phoneNumber());
+        assertEquals(member.getEmail(), result.email());
+    }
+
+    @Test
+    @DisplayName("readSinittoBankInfo 메소드 테스트")
+    void readSinittoBankInfoTest(){
+        //given
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Long memberId = 1L;
+        SinittoBankInfo sinittoBankInfo = new SinittoBankInfo("newTestBankName", "987654321", member);
+
+        when(sinittoBankInfoRepository.findByMemberId(memberId)).thenReturn(Optional.of(sinittoBankInfo));
+
+        //when
+        SinittoBankResponse result = sinittoService.readSinittoBankInfo(memberId);
+
+        //then
+        assertEquals(result.accountNumber(), sinittoBankInfo.getAccountNumber());
+        assertEquals(result.bankName(), sinittoBankInfo.getBankName());
+    }
+
+    @Test
+    @DisplayName("readSinittoBankInfo 메소드 테스트 - sinittoBankInfo에 참조된 Member가 없을 때")
+    void readSinittoBankInfoTestWithNull(){
+        //given
+        Member member = new Member("testName", "01012345678", "test@mail.com", false);
+        Long memberId = 1L;
+
+        when(sinittoBankInfoRepository.findByMemberId(memberId)).thenReturn(Optional.ofNullable(null));
+
+        //when
+        SinittoBankResponse result = sinittoService.readSinittoBankInfo(memberId);
+
+        //then
+        assertNull(result.accountNumber());
+        assertNull(result.bankName());
+    }
+
+    @Test
+    @DisplayName("updateSinitto 메소드 테스트")
+    void updateSinittoTest(){
+        //given
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        SinittoRequest sinittoRequest = new SinittoRequest("newTestName", "01011111111");
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        //when
+        sinittoService.updateSinitto(memberId, sinittoRequest);
+
+        //then
+        verify(member,times(1)).updateMember(sinittoRequest.name(), sinittoRequest.phoneNumber());
+    }
+
+    @Test
+    @DisplayName("updateSinittoBankInfo 메소드 테스트")
+    void updateSinittoBankInfo(){
+        //given
+        Long memberId = 1L;
+        SinittoBankInfo sinittoBankInfo = mock(SinittoBankInfo.class);
+        SinittoBankRequest sinittoBankRequest = new SinittoBankRequest("987654321", "newTestBankName");
+
+        when(sinittoBankInfoRepository.findByMemberId(memberId)).thenReturn(Optional.of(sinittoBankInfo));
+
+        //when
+        sinittoService.updateSinittoBankInfo(memberId, sinittoBankRequest);
+
+        //then
+        verify(sinittoBankInfo,times(1)).updateSinitto(sinittoBankRequest.bankName(), sinittoBankRequest.accountNumber());
+    }
+}

--- a/src/test/java/com/example/sinitto/sinitto/service/SinittoServiceTest.java
+++ b/src/test/java/com/example/sinitto/sinitto/service/SinittoServiceTest.java
@@ -102,7 +102,7 @@ public class SinittoServiceTest {
     @DisplayName("updateSinitto 메소드 테스트")
     void updateSinittoTest() {
         //given
-        Member member = mock(Member.class);
+        Member member = new Member("testName", "01000000000", "test@email.com", true);
         Long memberId = 1L;
         SinittoRequest sinittoRequest = new SinittoRequest("newTestName", "01011111111");
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
@@ -111,15 +111,17 @@ public class SinittoServiceTest {
         sinittoService.updateSinitto(memberId, sinittoRequest);
 
         //then
-        verify(member, times(1)).updateMember(sinittoRequest.name(), sinittoRequest.phoneNumber());
+        assertEquals(member.getName(), sinittoRequest.name());
+        assertEquals(member.getPhoneNumber(), sinittoRequest.phoneNumber());
     }
 
     @Test
     @DisplayName("updateSinittoBankInfo 메소드 테스트")
     void updateSinittoBankInfo() {
         //given
+        Member member = mock(Member.class);
         Long memberId = 1L;
-        SinittoBankInfo sinittoBankInfo = mock(SinittoBankInfo.class);
+        SinittoBankInfo sinittoBankInfo = new SinittoBankInfo("testBankName", "12345678", member);
         SinittoBankRequest sinittoBankRequest = new SinittoBankRequest("987654321", "newTestBankName");
 
         when(sinittoBankInfoRepository.findByMemberId(memberId)).thenReturn(Optional.of(sinittoBankInfo));
@@ -128,6 +130,7 @@ public class SinittoServiceTest {
         sinittoService.updateSinittoBankInfo(memberId, sinittoBankRequest);
 
         //then
-        verify(sinittoBankInfo, times(1)).updateSinitto(sinittoBankRequest.bankName(), sinittoBankRequest.accountNumber());
+        assertEquals(sinittoBankInfo.getBankName(), sinittoBankRequest.bankName());
+        assertEquals(sinittoBankInfo.getAccountNumber(), sinittoBankRequest.accountNumber());
     }
 }

--- a/src/test/java/com/example/sinitto/sinitto/service/SinittoServiceTest.java
+++ b/src/test/java/com/example/sinitto/sinitto/service/SinittoServiceTest.java
@@ -31,7 +31,7 @@ public class SinittoServiceTest {
 
     @Test
     @DisplayName("createSinittoBankInfo 메소드 테스트")
-    void createSinittoBankInfoTest(){
+    void createSinittoBankInfoTest() {
         //given
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
         Long memberId = 1L;
@@ -42,12 +42,12 @@ public class SinittoServiceTest {
         sinittoService.createSinittoBankInfo(memberId, sinittoBankRequest);
 
         //then
-        verify(sinittoBankInfoRepository,times(1)).save(any(SinittoBankInfo.class));
+        verify(sinittoBankInfoRepository, times(1)).save(any(SinittoBankInfo.class));
     }
 
     @Test
     @DisplayName("readSinitto 메소드 테스트")
-    void readSinittoTest(){
+    void readSinittoTest() {
         //given
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
         Long memberId = 1L;
@@ -65,7 +65,7 @@ public class SinittoServiceTest {
 
     @Test
     @DisplayName("readSinittoBankInfo 메소드 테스트")
-    void readSinittoBankInfoTest(){
+    void readSinittoBankInfoTest() {
         //given
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
         Long memberId = 1L;
@@ -83,7 +83,7 @@ public class SinittoServiceTest {
 
     @Test
     @DisplayName("readSinittoBankInfo 메소드 테스트 - sinittoBankInfo에 참조된 Member가 없을 때")
-    void readSinittoBankInfoTestWithNull(){
+    void readSinittoBankInfoTestWithNull() {
         //given
         Member member = new Member("testName", "01012345678", "test@mail.com", false);
         Long memberId = 1L;
@@ -100,7 +100,7 @@ public class SinittoServiceTest {
 
     @Test
     @DisplayName("updateSinitto 메소드 테스트")
-    void updateSinittoTest(){
+    void updateSinittoTest() {
         //given
         Member member = mock(Member.class);
         Long memberId = 1L;
@@ -111,12 +111,12 @@ public class SinittoServiceTest {
         sinittoService.updateSinitto(memberId, sinittoRequest);
 
         //then
-        verify(member,times(1)).updateMember(sinittoRequest.name(), sinittoRequest.phoneNumber());
+        verify(member, times(1)).updateMember(sinittoRequest.name(), sinittoRequest.phoneNumber());
     }
 
     @Test
     @DisplayName("updateSinittoBankInfo 메소드 테스트")
-    void updateSinittoBankInfo(){
+    void updateSinittoBankInfo() {
         //given
         Long memberId = 1L;
         SinittoBankInfo sinittoBankInfo = mock(SinittoBankInfo.class);
@@ -128,6 +128,6 @@ public class SinittoServiceTest {
         sinittoService.updateSinittoBankInfo(memberId, sinittoBankRequest);
 
         //then
-        verify(sinittoBankInfo,times(1)).updateSinitto(sinittoBankRequest.bankName(), sinittoBankRequest.accountNumber());
+        verify(sinittoBankInfo, times(1)).updateSinitto(sinittoBankRequest.bankName(), sinittoBankRequest.accountNumber());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #125 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- member 간 가능한 행동에 제약 추가(Ex. 시니또 -> 시니어 추가 불가하게 등, Member 엔티티의 isSinitto 변수 활용하여 진행)
- auth 도메인의 Service 레이어 테스트 코드 추가 (단, 카카오 외부 api의 경우는 제외하고 작성함. TokenService.refreshAccessToken의 경우 내부 함수를 다시 불러서 어떻게 해야될 지 잘 모르겠네요...)
- guard 도메인의 Service 레이어 테스트 코드 추가
- guardGuideline 도메인의 Service 레이어 테스트 코드 추가
- hellocall 도메인의 Service 레이어 테스트 코드 추가
- member 도메인의 Service 레이어 테스트 코드 추가(단, 카카오 외부 api 경우는 제외하고 작성함)
- sinitto 도메인의 Service 레이어 테스트 코드 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 각 도메인 별로 테스트 코드를 작성하고 있는데, 각자 맡으신 도메인에 대한 테스트 코드가 적절한지 확인해주시면 좋을 것 같습니다! 혹시 제가 로직을 제대로 이해하지 못했을까봐 걱정이네요...ㅠㅠ
> 11/3 기준으로 RestTemplate를 사용하는 카카오 api 부분을 제외하고는 대부분 작성했습니다!


## ⏰ 현재 버그


## ✏ Git Close
> close #125
