### PR TITLE
Refactor: 포인트관련 로직을 포인트 서비스계층으로 통합, 개별 트랜잭션 적용, 테스트 코드 개선

### DIFF
--- a/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
+++ b/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
@@ -20,7 +20,7 @@ public interface CallbackRepository extends JpaRepository<Callback, Long> {
 
     Page<Callback> findAllBySeniorIn(List<Senior> seniors, Pageable pageable);
 
-    List<Callback> findAllByStatusAndPendingCompleteTimeBefore(Callback.Status status, LocalDateTime dateTime);
+    List<Callback> findAllByStatusAndPendingCompleteTimeBetween(Callback.Status status, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
     boolean existsBySeniorAndStatusIn(Senior senior, List<Callback.Status> statuses);
 }

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -103,7 +103,7 @@ public class CallbackService {
 
         LocalDateTime referenceDateTimeForComplete = LocalDateTime.now().minusDays(DAYS_FOR_AUTO_COMPLETE);
 
-        List<Callback> callbacks = callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(Callback.Status.PENDING_COMPLETE, referenceDateTimeForComplete);
+        List<Callback> callbacks = callbackRepository.findAllByStatusAndPendingCompleteTimeBetween(Callback.Status.PENDING_COMPLETE, referenceDateTimeForComplete.minusMinutes(5), referenceDateTimeForComplete.plusMinutes(5));
 
         for (Callback callback : callbacks) {
             completeCallbackIndividually(callback);

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -113,7 +113,6 @@ public class CallbackService {
     }
 
     @Scheduled(cron = "0 */10 * * * *")
-    @Transactional
     public void changeOldPendingCompleteToCompleteByPolicy() {
 
         LocalDateTime referenceDateTimeForComplete = LocalDateTime.now().minusDays(DAYS_FOR_AUTO_COMPLETE);
@@ -121,10 +120,16 @@ public class CallbackService {
         List<Callback> callbacks = callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(Callback.Status.PENDING_COMPLETE, referenceDateTimeForComplete);
 
         for (Callback callback : callbacks) {
-
-            earnPointForSinitto(callback.getAssignedMemberId());
-            callback.changeStatusToComplete();
+            completeCallbackIndividually(callback);
         }
+    }
+
+    @Transactional
+    public void completeCallbackIndividually(Callback callback) {
+
+        earnPointForSinitto(callback.getAssignedMemberId());
+        callback.changeStatusToComplete();
+
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -95,7 +95,7 @@ public class CallbackService {
         Long guardId = senior.getMember().getId();
 
         if (!guardId.equals(memberId)) {
-            throw new ForbiddenException("이 API를 요청한 보호자는 이 콜백을 요청 한 시니어의 보호자가 아닙니다.");
+            throw new ForbiddenException("이 API 를 요청한 보호자는 이 콜백을 요청 한 시니어의 보호자가 아닙니다.");
         }
 
         earnPointForSinitto(callback.getAssignedMemberId());
@@ -145,12 +145,16 @@ public class CallbackService {
 
         String phoneNumber = TwilioHelper.trimPhoneNumber(fromNumber);
 
-        Senior senior = findSeniorByPhoneNumber(phoneNumber);
+        Senior senior = seniorRepository.findByPhoneNumber(phoneNumber)
+                .orElse(null);
+
         if (senior == null) {
             return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_NOT_ENROLLED);
         }
 
-        Point point = findPointWithWriteLock(senior.getMember().getId());
+        Point point = pointRepository.findByMemberIdWithWriteLock(senior.getMember().getId())
+                .orElse(null);
+
         if (point == null || !point.isSufficientForDeduction(CALLBACK_PRICE)) {
             return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_NOT_ENOUGH_POINT);
         }
@@ -171,16 +175,6 @@ public class CallbackService {
         callbackRepository.save(new Callback(Callback.Status.WAITING, senior));
 
         return TwilioHelper.convertMessageToTwiML(SUCCESS_MESSAGE);
-    }
-
-    private Senior findSeniorByPhoneNumber(String phoneNumber) {
-        return seniorRepository.findByPhoneNumber(phoneNumber)
-                .orElse(null);
-    }
-
-    private Point findPointWithWriteLock(Long memberId) {
-        return pointRepository.findByMemberIdWithWriteLock(memberId)
-                .orElse(null);
     }
 
     public CallbackResponse getAcceptedCallback(Long memberId) {

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -13,10 +13,8 @@ import com.example.sinitto.guard.repository.SeniorRepository;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
-import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
-import com.example.sinitto.point.repository.PointLogRepository;
-import com.example.sinitto.point.repository.PointRepository;
+import com.example.sinitto.point.service.PointService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -38,21 +36,19 @@ public class CallbackService {
     private final CallbackRepository callbackRepository;
     private final MemberRepository memberRepository;
     private final SeniorRepository seniorRepository;
-    private final PointRepository pointRepository;
-    private final PointLogRepository pointLogRepository;
+    private final PointService pointService;
 
-    public CallbackService(CallbackRepository callbackRepository, MemberRepository memberRepository, SeniorRepository seniorRepository, PointRepository pointRepository, PointLogRepository pointLogRepository) {
+    public CallbackService(CallbackRepository callbackRepository, MemberRepository memberRepository, SeniorRepository seniorRepository, PointService pointService) {
         this.callbackRepository = callbackRepository;
         this.memberRepository = memberRepository;
         this.seniorRepository = seniorRepository;
-        this.pointRepository = pointRepository;
-        this.pointLogRepository = pointLogRepository;
+        this.pointService = pointService;
     }
 
     @Transactional(readOnly = true)
     public Page<CallbackResponse> getWaitingCallbacks(Long memberId, Pageable pageable) {
 
-        checkAuthorization(memberId);
+        checkIsSinitto(memberId);
 
         return callbackRepository.findAllByStatus(Callback.Status.WAITING, pageable)
                 .map((callback) -> new CallbackResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus(), callback.getSeniorId()));
@@ -61,7 +57,7 @@ public class CallbackService {
     @Transactional
     public void acceptCallbackBySinitto(Long memberId, Long callbackId) {
 
-        checkAuthorization(memberId);
+        checkIsSinitto(memberId);
 
         if (callbackRepository.existsByAssignedMemberIdAndStatus(memberId, Callback.Status.IN_PROGRESS)) {
             throw new ConflictException("이 요청을 한 시니또는 이미 진행중인 콜백이 있습니다.");
@@ -76,7 +72,7 @@ public class CallbackService {
     @Transactional
     public void changeCallbackStatusToPendingCompleteBySinitto(Long memberId, Long callbackId) {
 
-        checkAuthorization(memberId);
+        checkIsSinitto(memberId);
 
         Callback callback = getCallbackOrThrow(callbackId);
 
@@ -98,18 +94,8 @@ public class CallbackService {
             throw new ForbiddenException("이 API 를 요청한 보호자는 이 콜백을 요청 한 시니어의 보호자가 아닙니다.");
         }
 
-        earnPointForSinitto(callback.getAssignedMemberId());
+        pointService.earnPoint(callback.getAssignedMemberId(), CALLBACK_PRICE, PointLog.Content.COMPLETE_CALLBACK_AND_EARN);
         callback.changeStatusToComplete();
-    }
-
-    private void earnPointForSinitto(Long sinittoMemberId) {
-
-        Point sinittoPoint = pointRepository.findByMemberId(sinittoMemberId)
-                .orElseThrow(() -> new NotFoundException("포인트 적립 받을 시니또와 연관된 포인트가 없습니다"));
-
-        sinittoPoint.earn(CALLBACK_PRICE);
-
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN.getMessage(), sinittoPoint.getMember(), CALLBACK_PRICE, PointLog.Status.EARN));
     }
 
     @Scheduled(cron = "0 */10 * * * *")
@@ -127,15 +113,14 @@ public class CallbackService {
     @Transactional
     public void completeCallbackIndividually(Callback callback) {
 
-        earnPointForSinitto(callback.getAssignedMemberId());
+        pointService.earnPoint(callback.getAssignedMemberId(), CALLBACK_PRICE, PointLog.Content.COMPLETE_CALLBACK_AND_EARN);
         callback.changeStatusToComplete();
-
     }
 
     @Transactional
     public void cancelCallbackAssignmentBySinitto(Long memberId, Long callbackId) {
 
-        checkAuthorization(memberId);
+        checkIsSinitto(memberId);
 
         Callback callback = getCallbackOrThrow(callbackId);
 
@@ -157,34 +142,25 @@ public class CallbackService {
             return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_NOT_ENROLLED);
         }
 
-        Point point = pointRepository.findByMemberIdWithWriteLock(senior.getMember().getId())
-                .orElse(null);
-
-        if (point == null || !point.isSufficientForDeduction(CALLBACK_PRICE)) {
-            return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_NOT_ENOUGH_POINT);
-        }
-
         if (callbackRepository.existsBySeniorAndStatusIn(senior, List.of(Callback.Status.WAITING, Callback.Status.IN_PROGRESS))) {
             return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_ALREADY_HAS_CALLBACK_IN_PROGRESS_OR_WAITING);
         }
 
-        point.deduct(CALLBACK_PRICE);
+        try {
+            pointService.deductPoint(senior.getMember().getId(), CALLBACK_PRICE, PointLog.Content.SPEND_COMPLETE_CALLBACK);
+        } catch (Exception e) {
+            return TwilioHelper.convertMessageToTwiML(FAIL_MESSAGE_NOT_ENOUGH_POINT);
+        }
 
-        pointLogRepository.save(
-                new PointLog(
-                        PointLog.Content.SPEND_COMPLETE_CALLBACK.getMessage(),
-                        senior.getMember(),
-                        CALLBACK_PRICE,
-                        PointLog.Status.SPEND_COMPLETE)
-        );
         callbackRepository.save(new Callback(Callback.Status.WAITING, senior));
 
         return TwilioHelper.convertMessageToTwiML(SUCCESS_MESSAGE);
     }
 
+    @Transactional(readOnly = true)
     public CallbackResponse getAcceptedCallback(Long memberId) {
 
-        checkAuthorization(memberId);
+        checkIsSinitto(memberId);
 
         Callback callback = callbackRepository.findByAssignedMemberIdAndStatus(memberId, Callback.Status.IN_PROGRESS)
                 .orElseThrow(() -> new NotFoundException("요청한 시니또에 할당된 콜백이 없습니다"));
@@ -192,7 +168,7 @@ public class CallbackService {
         return new CallbackResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus(), callback.getSeniorId());
     }
 
-    private void checkAuthorization(Long memberId) {
+    private void checkIsSinitto(Long memberId) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("멤버가 아닙니다"));
@@ -223,11 +199,11 @@ public class CallbackService {
 
         List<Senior> seniors = seniorRepository.findAllByMember(member);
 
-
         return callbackRepository.findAllBySeniorIn(seniors, pageable)
                 .map(callback -> new CallbackUsageHistoryResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus()));
     }
 
+    @Transactional(readOnly = true)
     public CallbackForSinittoResponse getCallbackForSinitto(Long memberId, Long callbackId) {
 
         Callback callback = callbackRepository.findById(callbackId)

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -15,10 +15,8 @@ import com.example.sinitto.helloCall.repository.TimeSlotRepository;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
-import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
-import com.example.sinitto.point.repository.PointLogRepository;
-import com.example.sinitto.point.repository.PointRepository;
+import com.example.sinitto.point.service.PointService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -38,20 +36,18 @@ public class HelloCallService {
     private final SeniorRepository seniorRepository;
     private final MemberRepository memberRepository;
     private final HelloCallTimeLogRepository helloCallTimeLogRepository;
-    private final PointRepository pointRepository;
-    private final PointLogRepository pointLogRepository;
+    private final PointService pointService;
 
 
     public HelloCallService(HelloCallRepository helloCallRepository, TimeSlotRepository timeSlotRepository,
-                            SeniorRepository seniorRepository, MemberRepository memberRepository, HelloCallTimeLogRepository helloCallTimeLogRepository,
-                            PointRepository pointRepository, PointLogRepository pointLogRepository) {
+                            SeniorRepository seniorRepository, MemberRepository memberRepository,
+                            HelloCallTimeLogRepository helloCallTimeLogRepository, PointService pointService) {
         this.helloCallRepository = helloCallRepository;
         this.timeSlotRepository = timeSlotRepository;
         this.seniorRepository = seniorRepository;
         this.memberRepository = memberRepository;
         this.helloCallTimeLogRepository = helloCallTimeLogRepository;
-        this.pointRepository = pointRepository;
-        this.pointLogRepository = pointLogRepository;
+        this.pointService = pointService;
     }
 
     @Transactional
@@ -73,22 +69,7 @@ public class HelloCallService {
             timeSlotRepository.save(timeSlot);
         }
 
-        Point point = pointRepository.findByMemberIdWithWriteLock(memberId)
-                .orElseThrow(() -> new NotFoundException("멤버에 연관된 포인트가 없습니다."));
-
-        if (!point.isSufficientForDeduction(helloCall.getPrice())) {
-            throw new BadRequestException("포인트가 부족합니다.");
-        }
-
-        point.deduct(helloCall.getPrice());
-
-        pointLogRepository.save(
-                new PointLog(
-                        PointLog.Content.SPEND_COMPLETE_HELLO_CALL.getMessage(),
-                        senior.getMember(),
-                        helloCall.getPrice(),
-                        PointLog.Status.SPEND_COMPLETE
-                ));
+        pointService.deductPoint(memberId, helloCall.getPrice(), PointLog.Content.SPEND_COMPLETE_HELLO_CALL);
     }
 
     @Transactional
@@ -178,18 +159,7 @@ public class HelloCallService {
 
         helloCall.checkGuardIsCorrect(member);
 
-        Point point = pointRepository.findByMemberIdWithWriteLock(memberId)
-                .orElseThrow(() -> new NotFoundException("멤버에 연관된 포인트가 없습니다."));
-
-        point.earn(helloCall.getPrice());
-
-        pointLogRepository.save(
-                new PointLog(
-                        PointLog.Content.SPEND_CANCEL_HELLO_CALL.getMessage(),
-                        member,
-                        helloCall.getPrice(),
-                        PointLog.Status.SPEND_CANCEL)
-        );
+        pointService.refundPointByDelete(memberId, helloCall.getPrice(), PointLog.Content.SPEND_CANCEL_HELLO_CALL);
 
         helloCall.checkStatusIsWaiting();
         helloCallRepository.delete(helloCall);
@@ -248,18 +218,7 @@ public class HelloCallService {
 
         helloCall.changeStatusToComplete();
 
-        Point sinittoPoint = pointRepository.findByMember(helloCall.getMember())
-                .orElseThrow(() -> new NotFoundException("포인트 적립 받을 시니또와 연관된 포인트가 없습니다"));
-
-        sinittoPoint.earn(helloCall.getPrice());
-
-        pointLogRepository.save(
-                new PointLog(
-                        PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN.getMessage(),
-                        sinittoPoint.getMember(),
-                        helloCall.getPrice(),
-                        PointLog.Status.EARN)
-        );
+        pointService.earnPoint(helloCall.getMember().getId(), helloCall.getPrice(), PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -97,4 +97,64 @@ public class PointService {
 
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST.getMessage(), member, adjustedPrice, PointLog.Status.WITHDRAW_REQUEST));
     }
+
+    @Transactional
+    public void earnPoint(Long memberId, int price, PointLog.Content contentForPointLog) {
+
+        Point point = pointRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotFoundException("멤버에 연관된 포인트가 없습니다."));
+
+        point.earn(price);
+
+        pointLogRepository.save(
+                new PointLog(
+                        contentForPointLog.getMessage(),
+                        point.getMember(),
+                        price,
+                        PointLog.Status.EARN)
+        );
+    }
+
+    @Transactional
+    public void deductPoint(Long memberId, int price, PointLog.Content contentForPointLog) {
+
+        Point point = pointRepository.findByMemberIdWithWriteLock(memberId)
+                .orElseThrow(() -> new NotFoundException("멤버에 연관된 포인트가 없습니다."));
+
+        if (!point.isSufficientForDeduction(price)) {
+            throw new BadRequestException("포인트가 부족합니다.");
+        }
+
+        point.deduct(price);
+
+        pointLogRepository.save(
+                new PointLog(
+                        contentForPointLog.getMessage(),
+                        point.getMember(),
+                        price,
+                        PointLog.Status.SPEND_COMPLETE
+                ));
+    }
+
+    @Transactional
+    public void refundPointByDelete(Long memberId, int price, PointLog.Content contentForPointLog) {
+
+        Point point = pointRepository.findByMemberIdWithWriteLock(memberId)
+                .orElseThrow(() -> new NotFoundException("멤버에 연관된 포인트가 없습니다."));
+
+        if (!point.isSufficientForDeduction(price)) {
+            throw new BadRequestException("포인트가 부족합니다.");
+        }
+
+        point.deduct(price);
+
+        pointLogRepository.save(
+                new PointLog(
+                        contentForPointLog.getMessage(),
+                        point.getMember(),
+                        price,
+                        PointLog.Status.SPEND_CANCEL
+                ));
+    }
+
 }

--- a/src/test/java/com/example/sinitto/callback/repository/CallbackRepositoryTest.java
+++ b/src/test/java/com/example/sinitto/callback/repository/CallbackRepositoryTest.java
@@ -173,7 +173,7 @@ class CallbackRepositoryTest {
 
 
     @Test
-    @DisplayName("findAllByStatusAndPendingCompleteTimeBefore 이용해서 2일이 지난 PendingComplete 콜백 조회 - 성공")
+    @DisplayName("findAllByStatusAndPendingCompleteTimeBetween 이용해서 2일이 지난 PendingComplete 콜백 조회 - 성공")
     void findAllByStatusAndPendingCompleteTimeBefore_success() {
         // given
         LocalDateTime beforeTime = LocalDateTime.of(2024, 1, 5, 13, 00).minusDays(2);
@@ -191,29 +191,29 @@ class CallbackRepositoryTest {
         callback5.setPendingCompleteTime(LocalDateTime.of(2024, 1, 3, 13, 02));
 
         // when
-        List<Callback> result = callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(Callback.Status.PENDING_COMPLETE, beforeTime);
+        List<Callback> result = callbackRepository.findAllByStatusAndPendingCompleteTimeBetween(Callback.Status.PENDING_COMPLETE, beforeTime.minusMinutes(5), beforeTime.plusMinutes(5));
 
         // then
-        assertEquals(3, result.size());
+        assertEquals(5, result.size());
         assertTrue(result.contains(callback1));
         assertTrue(result.contains(callback2));
         assertTrue(result.contains(callback3));
     }
 
     @Test
-    @DisplayName("findAllByStatusAndPendingCompleteTimeBefore 이용해서 2일이 지난 PendingComplete 콜백 조회 - 만약 아무것도 조건에 해당 안될 경우 테스트")
+    @DisplayName("findAllByStatusAndPendingCompleteTimeBetween 이용해서 2일이 지난 PendingComplete 콜백 조회 - 만약 아무것도 조건에 해당 안될 경우 테스트")
     void findAllByStatusAndPendingCompleteTimeBefore_success_zeroList() {
         // given
         LocalDateTime beforeTime = LocalDateTime.of(2024, 1, 5, 13, 00).minusDays(2);
         Senior testSenior = seniorRepository.save(new Senior("senior", "01012341234", testMember));
 
         Callback callback1 = callbackRepository.save(new Callback(Callback.Status.PENDING_COMPLETE, testSenior));
-        callback1.setPendingCompleteTime(LocalDateTime.of(2024, 1, 3, 13, 01));
+        callback1.setPendingCompleteTime(LocalDateTime.of(2024, 1, 3, 13, 06));
         Callback callback2 = callbackRepository.save(new Callback(Callback.Status.PENDING_COMPLETE, testSenior));
-        callback2.setPendingCompleteTime(LocalDateTime.of(2024, 1, 3, 13, 02));
+        callback2.setPendingCompleteTime(LocalDateTime.of(2024, 1, 3, 12, 54));
 
         // when
-        List<Callback> result = callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(Callback.Status.PENDING_COMPLETE, beforeTime);
+        List<Callback> result = callbackRepository.findAllByStatusAndPendingCompleteTimeBetween(Callback.Status.PENDING_COMPLETE, beforeTime.minusMinutes(5), beforeTime.plusMinutes(5));
 
         // then
         assertNotNull(result);

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -368,7 +368,7 @@ class CallbackServiceTest {
 
             when(callback1.getAssignedMemberId()).thenReturn(1L);
 
-            when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
+            when(callbackRepository.findAllByStatusAndPendingCompleteTimeBetween(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class), any(LocalDateTime.class)))
                     .thenReturn(List.of(callback1));
 
             // When
@@ -383,7 +383,7 @@ class CallbackServiceTest {
         @DisplayName("조건에 맞는 콜백이 없는경우 pointService 는 절대 사용이 안된다")
         void changeOldPendingCompleteToCompleteByPolicy_Success_zeroList() {
             // Given
-            when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
+            when(callbackRepository.findAllByStatusAndPendingCompleteTimeBetween(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class), any(LocalDateTime.class)))
                     .thenReturn(List.of());
 
             // When

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -2,6 +2,7 @@ package com.example.sinitto.callback.service;
 
 import com.example.sinitto.callback.dto.CallbackForSinittoResponse;
 import com.example.sinitto.callback.dto.CallbackResponse;
+import com.example.sinitto.callback.dto.CallbackUsageHistoryResponse;
 import com.example.sinitto.callback.entity.Callback;
 import com.example.sinitto.callback.repository.CallbackRepository;
 import com.example.sinitto.callback.util.TwilioHelper;
@@ -13,9 +14,9 @@ import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
-import com.example.sinitto.point.repository.PointLogRepository;
-import com.example.sinitto.point.repository.PointRepository;
+import com.example.sinitto.point.service.PointService;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -42,445 +43,490 @@ class CallbackServiceTest {
     @Mock
     SeniorRepository seniorRepository;
     @Mock
-    PointRepository pointRepository;
-    @Mock
-    PointLogRepository pointLogRepository;
+    PointService pointService;
     @InjectMocks
     CallbackService callbackService;
 
-    @Test
-    @DisplayName("getCallbacks - 성공")
-    void getWaitingCallbacks() {
-        //given
-        Long memberId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        Member member = mock(Member.class);
+    @Nested
+    @DisplayName("대기 상태인 콜백 조회 테스트")
+    class GetWaitingCallbackTest {
 
+        @Test
+        @DisplayName("정상적인 시니또가 요청하면 성공적으로 조회가 된다")
+        void shouldGetWaitingCallbacks() {
+            //given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            Member member = mock(Member.class);
+
+            Callback callback = mock(Callback.class);
+            when(callback.getId()).thenReturn(1L);
+            when(callback.getPostTime()).thenReturn(LocalDateTime.now());
+            when(callback.getStatus()).thenReturn(Callback.Status.WAITING.name());
+            when(callback.getSeniorName()).thenReturn("James");
+            when(callback.getSeniorId()).thenReturn(1L);
+            Page<Callback> callbackPage = new PageImpl<>(List.of(callback));
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(callbackRepository.findAllByStatus(Callback.Status.WAITING, pageable)).thenReturn(callbackPage);
+
+            //when
+            Page<CallbackResponse> result = callbackService.getWaitingCallbacks(memberId, pageable);
+
+            //then
+            assertEquals(1, result.getContent().size());
+            assertEquals("James", result.getContent().getFirst().seniorName());
+        }
+
+        @Test
+        @DisplayName("memberId 가 Member DB에 없는 경우 예외를 발생시켜야 한다")
+        void getWaitingCallbacks_Fail_WhenNotMember() {
+            //given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            //when then
+            assertThrows(NotFoundException.class, () -> callbackService.getWaitingCallbacks(memberId, pageable));
+        }
+
+        @Test
+        @DisplayName("멤버이더라도 시니또가 아닌경우는 예외를 발생시켜야 한다")
+        void getCallbacks_Fail_WhenNotSinitto() {
+            //given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            Member member = mock(Member.class);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(false);
+
+            //when then
+            assertThrows(ForbiddenException.class, () -> callbackService.getWaitingCallbacks(memberId, pageable));
+        }
+    }
+
+    @Nested
+    @DisplayName("콜백 상태 변화 테스트")
+    class CallbackStatusChangeTest {
+
+        @Test
+        @DisplayName("시니또가 WAITING 상태인 콜백을 수락할 수 있다. 이를 시니또가 콜백을 할당 받는다고 표현함")
+        void acceptCallbackBySinitto() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+
+            //when
+            callbackService.acceptCallbackBySinitto(memberId, callbackId);
+
+            //then
+            verify(callback).assignMember(memberId);
+            verify(callback).changeStatusToInProgress();
+        }
+
+        @Test
+        @DisplayName("WAITING 상태인 콜백을 할당 받은 시니또가 할 일을 다하고, PENDING_COMPLETE 상태로 전환시킨다")
+        void changeCallbackStatusToCompleteByGuard() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+            Long assignedMemberId = 1L;
+
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getAssignedMemberId()).thenReturn(assignedMemberId);
+
+            //when
+            callbackService.changeCallbackStatusToPendingCompleteBySinitto(memberId, callbackId);
+
+            //then
+            verify(callback).changeStatusToPendingComplete();
+        }
+
+        @Test
+        @DisplayName("시니또가 본인이 수락하여 할당 받은 콜백을 취소할 수 있다")
+        void cancelCallbackAssignmentBySinitto() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getAssignedMemberId()).thenReturn(1L);
+
+            //when
+            callbackService.cancelCallbackAssignmentBySinitto(memberId, callbackId);
+
+            //then
+            verify(callback).cancelAssignment();
+            verify(callback).changeStatusToWaiting();
+        }
+
+        @Test
+        @DisplayName("보호자가 콜백 대기 상태를 완료 생태로 변경 - 성공")
+        void changeCallbackStatusToCompleteByGuardByGuard() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+            Senior senior = mock(Senior.class);
+
+            when(member.getId()).thenReturn(1L);
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getSenior()).thenReturn(senior);
+            when(senior.getMember()).thenReturn(member);
+            when(senior.getMember().getId()).thenReturn(1L);
+
+            //when
+            callbackService.changeCallbackStatusToCompleteByGuard(memberId, callbackId);
+
+            //then
+            verify(callback).changeStatusToComplete();
+        }
+
+        @Test
+        @DisplayName("보호자가 콜백 대기 상태를 완료 생태로 변경 - 일치하는 보호자 ID가 아니어서 실패")
+        void changeCallbackStatusToCompleteByGuardByGuard_fail() {
+            //given
+            Long memberId = 10L;
+            Long callbackId = 1L;
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+            Senior senior = mock(Senior.class);
+
+            when(member.getId()).thenReturn(1L);
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getSenior()).thenReturn(senior);
+            when(senior.getMember()).thenReturn(member);
+            when(senior.getMember().getId()).thenReturn(1L);
+
+            //when then
+            assertThrows(ForbiddenException.class, () -> callbackService.changeCallbackStatusToCompleteByGuard(memberId, callbackId));
+        }
+    }
+
+    @Nested
+    @DisplayName("시니어가 우리 서비스에 전화를 걸어 새로운 콜백 등록 테스트")
+    class CreateNewCallbackTest {
+
+        @Test
+        @DisplayName("성공적으로 새로운 콜백 등록되면 감사하다는 인사와 잠시만 기다려 달라는 메시지를 응답한다")
+        void createCallbackByCall() {
+            //given
+            String fromPhoneNumber = "+821012341234";
+            String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
+            Senior senior = mock(Senior.class);
+            Member member = mock(Member.class);
+
+            when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
+            when(senior.getMember()).thenReturn(member);
+            when(member.getId()).thenReturn(1L);
+
+            //when
+            String result = callbackService.createCallbackByCall(fromPhoneNumber);
+
+            //then
+            assertEquals(TwilioHelper.convertMessageToTwiML("감사합니다. 잠시만 기다려주세요."), result);
+            verify(callbackRepository, times(1)).save(any());
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("서비스로 걸려온 전화번호가 등록된 번호가 아닐 때, 등록된 사용자가 아니라는 메시지를 응답한다")
+        void createCallbackByCallingCallback_fail() {
+            //given
+            String fromPhoneNumber = "+821012341234";
+            String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
+
+            when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.empty());
+
+            //when
+            String result = callbackService.createCallbackByCall(fromPhoneNumber);
+
+            //then
+            assertEquals(TwilioHelper.convertMessageToTwiML("등록된 사용자가 아닙니다. 서비스 이용이 불가합니다."), result);
+            verify(callbackRepository, never()).save(any());
+            verify(pointService, never()).deductPoint(anyLong(), anyInt(), any());
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("새로운 콜백 등록할 때 포인트가 부족할 때, 포인트가 부족하다는 메시지를 응답한다")
+        void createCallbackByCallingCallback_fail1() {
+            //given
+            String fromPhoneNumber = "+821012341234";
+            String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
+            Member member = mock(Member.class);
+            Senior senior = mock(Senior.class);
+
+            when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
+            when(senior.getMember()).thenReturn(member);
+            when(member.getId()).thenReturn(1L);
+            doThrow(new ForbiddenException("포인트 부족")).when(pointService).deductPoint(anyLong(), anyInt(), any(PointLog.Content.class));
+
+            //when
+            String result = callbackService.createCallbackByCall(fromPhoneNumber);
+
+            //then
+            assertEquals(TwilioHelper.convertMessageToTwiML("포인트가 부족합니다. 서비스 이용이 불가합니다."), result);
+            verify(callbackRepository, never()).save(any());
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("이미 시니어가 신청한 콜백이 대기중이거나 진행중일때, 이미 접수된 콜백이 있다는 메시지를 응답한다")
+        void createCallbackByCallingCallback_fail2() {
+            //given
+            String fromPhoneNumber = "+821012341234";
+            String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
+            Senior senior = mock(Senior.class);
+            Point point = mock(Point.class);
+
+            when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
+            when(callbackRepository.existsBySeniorAndStatusIn(any(), any())).thenReturn(true);
+
+            //when
+            String result = callbackService.createCallbackByCall(fromPhoneNumber);
+
+            //then
+            assertEquals(TwilioHelper.convertMessageToTwiML("어르신의 요청이 이미 접수되었습니다. 잠시 기다려주시면 연락드리겠습니다."), result);
+            verify(point, never()).deduct(anyInt());
+            verify(callbackRepository, never()).save(any());
+            assertNotNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("시니또에 할당 된 콜백 조회 테스트")
+    class GetAssignedCallbackTest {
+
+        @Test
+        @DisplayName("시니또에게 할당된 콜백이 있으면 조회가 된다")
+        void getAcceptedCallback() {
+            //given
+            Long memberId = 1L;
+            Callback callback = mock(Callback.class);
+            Member member = mock(Member.class);
+
+            //when
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(callback.getId()).thenReturn(10L);
+
+            when(callbackRepository.findByAssignedMemberIdAndStatus(memberId, Callback.Status.IN_PROGRESS)).thenReturn(Optional.of(callback));
+            CallbackResponse result = callbackService.getAcceptedCallback(memberId);
+
+            //then
+            assertEquals(10L, result.callbackId());
+        }
+
+        @Test
+        @DisplayName("시니또에게 할당된 콜백이 없으면 예외를 발생 시킨다")
+        void getAcceptedCallback_fail() {
+            //given
+            Long memberId = 1L;
+            Member member = mock(Member.class);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(callbackRepository.findByAssignedMemberIdAndStatus(memberId, Callback.Status.IN_PROGRESS)).thenReturn(Optional.empty());
+
+            //when then
+            assertThrows(NotFoundException.class, () -> callbackService.getAcceptedCallback(memberId));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("일정 기간동안 PENDING_COMPLETE 상태인 콜백 자동으로 COMPLETE 시키는 정책 테스트")
+    class CallbackPolicyTest {
+
+        @Test
+        @DisplayName("일정 기간동안 PENDING_COMPLETE 인 콜백 자동으로 COMPLETE 로 전환되고 시니또에게 포인트도 적립되야 한다")
+        void changeOldPendingCompleteToCompleteByPolicy_Success() {
+            // Given
+            Callback callback1 = mock(Callback.class);
+
+            when(callback1.getAssignedMemberId()).thenReturn(1L);
+
+            when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
+                    .thenReturn(List.of(callback1));
+
+            // When
+            callbackService.changeOldPendingCompleteToCompleteByPolicy();
+
+            // Then
+            verify(callback1, times(1)).changeStatusToComplete();
+            verify(pointService, times(1)).earnPoint(anyLong(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("조건에 맞는 콜백이 없는경우 pointService 는 절대 사용이 안된다")
+        void changeOldPendingCompleteToCompleteByPolicy_Success_zeroList() {
+            // Given
+            when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
+                    .thenReturn(List.of());
+
+            // When
+            callbackService.changeOldPendingCompleteToCompleteByPolicy();
+
+            // Then
+            verify(pointService, never()).earnPoint(anyLong(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("LocalDateTime 의 isBefore 메서드 공부 겸 테스트, 엣지 케이스")
+        void localDateTimeBeforeCalculateTest() {
+            //given
+            //메서드 실행 시간
+            LocalDateTime 일월3일13시00분 = LocalDateTime.of(2024, 1, 3, 13, 0);
+            LocalDateTime 일월3일13시10분 = LocalDateTime.of(2024, 1, 3, 13, 10);
+
+            //콜백이 Pending Complete 상태가 된 시간
+            LocalDateTime 일월1일12시59분 = LocalDateTime.of(2024, 1, 1, 12, 59);
+            LocalDateTime 일월1일13시00분 = LocalDateTime.of(2024, 1, 1, 13, 0);
+            LocalDateTime 일월1일13시01분 = LocalDateTime.of(2024, 1, 1, 13, 1);
+
+            //when then
+            // 1월 3일 13시 00분에 2일전에 COMPLETE 된 콜백의 존재를 확인한다.
+            assertTrue(일월1일12시59분.isBefore(일월3일13시00분.minusDays(2)));
+            assertFalse(일월1일13시00분.isBefore(일월3일13시00분.minusDays(2)));
+            assertFalse(일월1일13시01분.isBefore(일월3일13시00분.minusDays(2)));
+
+            //10분뒤인 1월 3일 13시 10분에 2일전에 COMPLETE 된 콜백의 존재를 확인한다. 결국 모두 TRUE 로 처리가 되는것을 확인.
+            assertTrue(일월1일12시59분.isBefore(일월3일13시10분.minusDays(2)));
+            assertTrue(일월1일13시00분.isBefore(일월3일13시10분.minusDays(2)));
+            assertTrue(일월1일13시01분.isBefore(일월3일13시10분.minusDays(2)));
+        }
+    }
+
+    @Nested
+    @DisplayName("시니또 전용 콜백 단건 조회")
+    class GetCallbackForSinitto {
+        @Test
+        @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 아님 + 해당 콜백에 할당 된 시니또 맞음")
+        void getCallbackForSinitto() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+            Callback callback = mock(Callback.class);
+            Senior senior = mock(Senior.class);
+
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+
+            when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
+            when(callback.getAssignedMemberId()).thenReturn(1L);
+            when(callback.getId()).thenReturn(1L);
+            when(callback.getSeniorName()).thenReturn("SeniorName");
+            when(callback.getPostTime()).thenReturn(LocalDateTime.now());
+            when(callback.getSeniorId()).thenReturn(1L);
+            when(callback.getSenior()).thenReturn(senior);
+            when(callback.getSenior().getPhoneNumber()).thenReturn("01012341234");
+
+            //when
+            CallbackForSinittoResponse result = callbackService.getCallbackForSinitto(memberId, callbackId);
+
+            //then
+            assertTrue(result.isAssignedToSelf());
+            assertEquals("01012341234", result.seniorPhoneNumber());
+        }
+
+        @Test
+        @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 인 상황은 예외를 던져야한다")
+        void getCallbackForSinitto2() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+            Callback callback = mock(Callback.class);
+
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getAssignedMemberId()).thenReturn(null);
+            when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
+
+            //when then
+            assertThrows(ForbiddenException.class, () -> callbackService.getCallbackForSinitto(memberId, callbackId));
+        }
+
+        @Test
+        @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 은 아닌데 해당 콜백에 할당된 시니또는 아닌 상황은 예외를 던져야 한다")
+        void getCallbackForSinitto3() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+            Callback callback = mock(Callback.class);
+
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getAssignedMemberId()).thenReturn(999L);
+            when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
+
+            //when then
+            assertThrows(ForbiddenException.class, () -> callbackService.getCallbackForSinitto(memberId, callbackId));
+        }
+
+        @Test
+        @DisplayName("시니또용 콜백 단건 조회 - 1.콜백이 '대기상태' 인 경우(모든 시니또가 조회 가능하다) 시니어 번호가 \"\" 로 전달되야한다")
+        void getCallbackForSinitto4() {
+            //given
+            Long memberId = 1L;
+            Long callbackId = 1L;
+            Callback callback = mock(Callback.class);
+
+            when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
+            when(callback.getStatus()).thenReturn(Callback.Status.WAITING.toString());
+
+            //when
+            CallbackForSinittoResponse result = callbackService.getCallbackForSinitto(memberId, callbackId);
+
+            //then
+            assertFalse(result.isAssignedToSelf());
+            assertEquals("", result.seniorPhoneNumber());
+        }
+    }
+
+    @Test
+    @DisplayName("보호자의 콜백 요청 내역 조회 테스트")
+    void getCallbackHistoryOfGuard() {
+        // given
+        Long memberId = 1L;
+        Member member = mock(Member.class);
+        Senior senior = mock(Senior.class);
+        List<Senior> seniors = List.of(senior);
         Callback callback = mock(Callback.class);
-        when(callback.getId()).thenReturn(1L);
-        when(callback.getPostTime()).thenReturn(LocalDateTime.now());
-        when(callback.getStatus()).thenReturn(Callback.Status.WAITING.name());
-        when(callback.getSeniorName()).thenReturn("James");
-        when(callback.getSeniorId()).thenReturn(1L);
         Page<Callback> callbackPage = new PageImpl<>(List.of(callback));
-
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(true);
-        when(callbackRepository.findAllByStatus(Callback.Status.WAITING, pageable)).thenReturn(callbackPage);
-
-        //when
-        Page<CallbackResponse> result = callbackService.getWaitingCallbacks(memberId, pageable);
-
-        //then
-        assertEquals(1, result.getContent().size());
-        assertEquals("James", result.getContent().getFirst().seniorName());
-    }
-
-    @Test
-    @DisplayName("getCallbacks 멤버가 없을때 - 실패")
-    void getWaitingCallbacks_Fail_WhenNotMember() {
-        //given
-        Long memberId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
 
-        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
-
-        //when then
-        assertThrows(NotFoundException.class, () -> callbackService.getWaitingCallbacks(memberId, pageable));
-    }
-
-    @Test
-    @DisplayName("getCallbacks 멤버가 시니또가 아닐때 - 실패")
-    void getCallbacks_Fail_WhenNotSinitto() {
-        //given
-        Long memberId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        Member member = mock(Member.class);
-
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(false);
-
-        //when then
-        assertThrows(ForbiddenException.class, () -> callbackService.getWaitingCallbacks(memberId, pageable));
-    }
-
-    @Test
-    @DisplayName("콜백 수락 - 성공")
-    void acceptCallbackBySinitto() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-
-        Member member = mock(Member.class);
-        Callback callback = mock(Callback.class);
-
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(true);
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-
-        //when
-        callbackService.acceptCallbackBySinitto(memberId, callbackId);
-
-        //then
-        verify(callback).assignMember(memberId);
-        verify(callback).changeStatusToInProgress();
-    }
-
-    @Test
-    @DisplayName("콜백 완료 대기 - 성공")
-    void changeCallbackStatusToCompleteByGuard() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-        Long assignedMemberId = 1L;
-
-        Member member = mock(Member.class);
-        Callback callback = mock(Callback.class);
-
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(true);
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getAssignedMemberId()).thenReturn(assignedMemberId);
-
-        //when
-        callbackService.changeCallbackStatusToPendingCompleteBySinitto(memberId, callbackId);
-
-        //then
-        verify(callback).changeStatusToPendingComplete();
-    }
-
-    @Test
-    @DisplayName("수락한 콜백 취소 - 성공")
-    void cancelCallbackAssignmentBySinitto() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-
-        Member member = mock(Member.class);
-        Callback callback = mock(Callback.class);
-
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(true);
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getAssignedMemberId()).thenReturn(1L);
-
-        //when
-        callbackService.cancelCallbackAssignmentBySinitto(memberId, callbackId);
-
-        //then
-        verify(callback).cancelAssignment();
-        verify(callback).changeStatusToWaiting();
-    }
-
-    @Test
-    @DisplayName("새로운 콜백 등록")
-    void createCallbackByCall() {
-        //given
-        String fromPhoneNumber = "+821012341234";
-        String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
-        Senior senior = mock(Senior.class);
-        Member member = mock(Member.class);
-        Point point = mock(Point.class);
-
-        when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
-        when(senior.getMember()).thenReturn(member);
-        when(member.getId()).thenReturn(1L);
-        when(pointRepository.findByMemberIdWithWriteLock(1L)).thenReturn(Optional.of(point));
-        when(point.isSufficientForDeduction(anyInt())).thenReturn(true);
-        //when
-        String result = callbackService.createCallbackByCall(fromPhoneNumber);
-
-        //then
-        verify(pointLogRepository, times(1)).save(any());
-        verify(callbackRepository, times(1)).save(any());
-        assertNotNull(result);
-    }
-
-    @Test
-    @DisplayName("새로운 콜백 등록할 때 전화온 번호가 등록된 번호가 아닐 때")
-    void createCallbackByCallingCallback_fail() {
-        //given
-        String fromPhoneNumber = "+821012341234";
-        String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
-
-        when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.empty());
-
-        //when
-        String result = callbackService.createCallbackByCall(fromPhoneNumber);
-
-        //then
-        verify(callbackRepository, never()).save(any());
-        assertNotNull(result);
-    }
-
-    @Test
-    @DisplayName("새로운 콜백 등록할 때 포인트가 부족할 때")
-    void createCallbackByCallingCallback_fail1() {
-        //given
-        String fromPhoneNumber = "+821012341234";
-        String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
-        Member member = mock(Member.class);
-        Senior senior = mock(Senior.class);
-        Point point = mock(Point.class);
-
-        when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
-        when(senior.getMember()).thenReturn(member);
-        when(member.getId()).thenReturn(1L);
-        when(pointRepository.findByMemberIdWithWriteLock(any(Long.class))).thenReturn(Optional.of(point));
-        when(point.isSufficientForDeduction(anyInt())).thenReturn(false);
-
-        //when
-        String result = callbackService.createCallbackByCall(fromPhoneNumber);
-
-        //then
-        verify(point, never()).deduct(anyInt());
-        verify(callbackRepository, never()).save(any());
-        assertNotNull(result);
-    }
-
-    @Test
-    @DisplayName("새로운 콜백 등록할 때 이미 시니어가 신청한 진행중 or 대기중인 콜백이 존재할때")
-    void createCallbackByCallingCallback_fail2() {
-        //given
-        String fromPhoneNumber = "+821012341234";
-        String trimmedPhoneNumber = TwilioHelper.trimPhoneNumber(fromPhoneNumber);
-        Member member = mock(Member.class);
-        Senior senior = mock(Senior.class);
-        Point point = mock(Point.class);
-
-        when(seniorRepository.findByPhoneNumber(trimmedPhoneNumber)).thenReturn(Optional.of(senior));
-        when(senior.getMember()).thenReturn(member);
-        when(member.getId()).thenReturn(1L);
-        when(pointRepository.findByMemberIdWithWriteLock(any(Long.class))).thenReturn(Optional.of(point));
-        when(point.isSufficientForDeduction(anyInt())).thenReturn(true);
-        when(callbackRepository.existsBySeniorAndStatusIn(any(), any())).thenReturn(true);
-
-        //when
-        String result = callbackService.createCallbackByCall(fromPhoneNumber);
-
-        //then
-        verify(point, never()).deduct(anyInt());
-        verify(callbackRepository, never()).save(any());
-        assertNotNull(result);
-    }
-
-    @Test
-    @DisplayName("보호자가 콜백 대기 상태를 완료 생태로 변경 - 성공")
-    void changeCallbackStatusToCompleteByGuardByGuard() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-        Member member = mock(Member.class);
-        Callback callback = mock(Callback.class);
-        Senior senior = mock(Senior.class);
-        Point point = mock(Point.class);
-
-        when(member.getId()).thenReturn(1L);
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getSenior()).thenReturn(senior);
-        when(senior.getMember()).thenReturn(member);
-        when(senior.getMember().getId()).thenReturn(1L);
-        when(pointRepository.findByMemberId(any())).thenReturn(Optional.of(point));
-
-        //when
-        callbackService.changeCallbackStatusToCompleteByGuard(memberId, callbackId);
-
-        //then
-        verify(callback).changeStatusToComplete();
-    }
-
-    @Test
-    @DisplayName("보호자가 콜백 대기 상태를 완료 생태로 변경 - 일치하는 보호자 ID가 아니어서 실패")
-    void changeCallbackStatusToCompleteByGuardByGuard_fail() {
-        //given
-        Long memberId = 10L;
-        Long callbackId = 1L;
-        Member member = mock(Member.class);
-        Callback callback = mock(Callback.class);
-        Senior senior = mock(Senior.class);
-
-        when(member.getId()).thenReturn(1L);
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getSenior()).thenReturn(senior);
-        when(senior.getMember()).thenReturn(member);
-        when(senior.getMember().getId()).thenReturn(1L);
-
-        //when then
-        assertThrows(ForbiddenException.class, () -> callbackService.changeCallbackStatusToCompleteByGuard(memberId, callbackId));
-    }
-
-    @Test
-    @DisplayName("콜백이 할당된 시니또 조회에 성공")
-    void getAcceptedCallback() {
-        //given
-        Long memberId = 1L;
-        Callback callback = mock(Callback.class);
-        Member member = mock(Member.class);
-
-        //when
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(true);
-        when(callback.getId()).thenReturn(10L);
-
-        when(callbackRepository.findByAssignedMemberIdAndStatus(memberId, Callback.Status.IN_PROGRESS)).thenReturn(Optional.of(callback));
-        CallbackResponse result = callbackService.getAcceptedCallback(memberId);
-
-        //then
-        assertEquals(10L, result.callbackId());
-    }
-
-    @Test
-    @DisplayName("콜백이 할당된 시니또 조회에 실패")
-    void getAcceptedCallback_fail() {
-        //given
-        Long memberId = 1L;
-        Member member = mock(Member.class);
-
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(member.isSinitto()).thenReturn(true);
-        when(callbackRepository.findByAssignedMemberIdAndStatus(memberId, Callback.Status.IN_PROGRESS)).thenReturn(Optional.empty());
-
-        //when then
-        assertThrows(NotFoundException.class, () -> callbackService.getAcceptedCallback(memberId));
-    }
-
-    @Test
-    @DisplayName("일정 기간동안 PendingComplete 인 콜백 자동으로 Complete 로 전환  - 성공")
-    void changeOldPendingCompleteToCompleteByPolicy_Success() {
-        // Given
-        Callback callback1 = mock(Callback.class);
-        Point point = mock(Point.class);
-
-        when(callback1.getAssignedMemberId()).thenReturn(1L);
-        when(pointRepository.findByMemberId(1L)).thenReturn(Optional.of(point));
-
-        when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
-                .thenReturn(List.of(callback1));
-
-        // When
-        callbackService.changeOldPendingCompleteToCompleteByPolicy();
-
-        // Then
-        verify(callback1, times(1)).changeStatusToComplete();
-        verify(point, times(1)).earn(1500);
-        verify(pointLogRepository, times(1)).save(any(PointLog.class));
-    }
-
-    @Test
-    @DisplayName("일정 기간동안 PendingComplete 인 콜백 자동으로 Complete 로 전환  - 조건에 맞는 콜백 없을 때")
-    void changeOldPendingCompleteToCompleteByPolicy_Success_zeroList() {
-        // Given
-        when(callbackRepository.findAllByStatusAndPendingCompleteTimeBefore(eq(Callback.Status.PENDING_COMPLETE), any(LocalDateTime.class)))
-                .thenReturn(List.of());
-
-        // When
-        callbackService.changeOldPendingCompleteToCompleteByPolicy();
-
-        // Then
-        verify(pointLogRepository, never()).save(any(PointLog.class));
-    }
-
-    @Test
-    @DisplayName("LocalDateTime 의 isBefore 메서드 공부 겸 테스트, 엣지 케이스")
-    void localDateTimeBeforeCalculateTest() {
-        //given
-        //메서드 실행 시간
-        LocalDateTime 일월3일13시00분 = LocalDateTime.of(2024, 1, 3, 13, 0);
-        LocalDateTime 일월3일13시10분 = LocalDateTime.of(2024, 1, 3, 13, 10);
-
-        //콜백이 Pending Complete 상태가 된 시간
-        LocalDateTime 일월1일12시59분 = LocalDateTime.of(2024, 1, 1, 12, 59);
-        LocalDateTime 일월1일13시00분 = LocalDateTime.of(2024, 1, 1, 13, 0);
-        LocalDateTime 일월1일13시01분 = LocalDateTime.of(2024, 1, 1, 13, 1);
-
-        //when then
-        // 1월 3일 13시 00분에 2일전에 COMPLETE 된 콜백의 존재를 확인한다.
-        assertTrue(일월1일12시59분.isBefore(일월3일13시00분.minusDays(2)));
-        assertFalse(일월1일13시00분.isBefore(일월3일13시00분.minusDays(2)));
-        assertFalse(일월1일13시01분.isBefore(일월3일13시00분.minusDays(2)));
-
-        //10분뒤인 1월 3일 13시 10분에 2일전에 COMPLETE 된 콜백의 존재를 확인한다. 결국 모두 TRUE 로 처리가 되는것을 확인.
-        assertTrue(일월1일12시59분.isBefore(일월3일13시10분.minusDays(2)));
-        assertTrue(일월1일13시00분.isBefore(일월3일13시10분.minusDays(2)));
-        assertTrue(일월1일13시01분.isBefore(일월3일13시10분.minusDays(2)));
-    }
-
-    @Test
-    @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 아님 + 해당 콜백에 할당 된 시니또 맞음 ")
-    void getCallbackForSinitto() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-        Callback callback = mock(Callback.class);
-        Senior senior = mock(Senior.class);
-
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-
-        when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
-        when(callback.getAssignedMemberId()).thenReturn(1L);
+        when(seniorRepository.findAllByMember(member)).thenReturn(seniors);
+        when(callbackRepository.findAllBySeniorIn(seniors, pageable)).thenReturn(callbackPage);
         when(callback.getId()).thenReturn(1L);
         when(callback.getSeniorName()).thenReturn("SeniorName");
         when(callback.getPostTime()).thenReturn(LocalDateTime.now());
-        when(callback.getSeniorId()).thenReturn(1L);
-        when(callback.getSenior()).thenReturn(senior);
-        when(callback.getSenior().getPhoneNumber()).thenReturn("01012341234");
+        when(callback.getStatus()).thenReturn(Callback.Status.WAITING.name());
 
-        //when
-        CallbackForSinittoResponse result = callbackService.getCallbackForSinitto(memberId, callbackId);
+        // when
+        Page<CallbackUsageHistoryResponse> result = callbackService.getCallbackHistoryOfGuard(memberId, pageable);
 
-        //then
-        assertTrue(result.isAssignedToSelf());
-        assertEquals("01012341234", result.seniorPhoneNumber());
-    }
-
-    @Test
-    @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 인 상황 ")
-    void getCallbackForSinitto2() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-        Callback callback = mock(Callback.class);
-
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getAssignedMemberId()).thenReturn(null);
-        when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
-
-        //when then
-        assertThrows(ForbiddenException.class, () -> callbackService.getCallbackForSinitto(memberId, callbackId));
-    }
-
-    @Test
-    @DisplayName("시니또용 콜백 단건 조회 - 1.대기상태 아님 2.AssignedMemberId 이 null 은 아닌데 해당 콜백에 할당된 시니또는 아닌 상황")
-    void getCallbackForSinitto3() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-        Callback callback = mock(Callback.class);
-
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getAssignedMemberId()).thenReturn(999L);
-        when(callback.getStatus()).thenReturn(Callback.Status.IN_PROGRESS.toString());
-
-        //when then
-        assertThrows(ForbiddenException.class, () -> callbackService.getCallbackForSinitto(memberId, callbackId));
-    }
-
-    @Test
-    @DisplayName("시니또용 콜백 단건 조회 - 1.콜백이 '대기상태' 인 경우(모든 시니또가 조회 가능하다)")
-    void getCallbackForSinitto4() {
-        //given
-        Long memberId = 1L;
-        Long callbackId = 1L;
-        Callback callback = mock(Callback.class);
-
-        when(callbackRepository.findById(callbackId)).thenReturn(Optional.of(callback));
-        when(callback.getStatus()).thenReturn(Callback.Status.WAITING.toString());
-
-        //when
-        CallbackForSinittoResponse result = callbackService.getCallbackForSinitto(memberId, callbackId);
-
-        //then
-        assertFalse(result.isAssignedToSelf());
-        assertEquals("", result.seniorPhoneNumber());
+        // then
+        assertEquals(1, result.getContent().size());
+        assertEquals("SeniorName", result.getContent().getFirst().seniorName());
     }
 }

--- a/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
@@ -16,10 +16,8 @@ import com.example.sinitto.helloCall.service.HelloCallService;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import com.example.sinitto.member.repository.MemberRepository;
-import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
-import com.example.sinitto.point.repository.PointLogRepository;
-import com.example.sinitto.point.repository.PointRepository;
+import com.example.sinitto.point.service.PointService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -34,9 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @MockitoSettings
 public class HelloCallServiceTest {
@@ -51,9 +48,7 @@ public class HelloCallServiceTest {
     @Mock
     HelloCallTimeLogRepository helloCallTimeLogRepository;
     @Mock
-    PointRepository pointRepository;
-    @Mock
-    PointLogRepository pointLogRepository;
+    PointService pointService;
     @InjectMocks
     HelloCallService helloCallService;
 
@@ -61,7 +56,6 @@ public class HelloCallServiceTest {
     @DisplayName("createHelloCallByGuard 메소드 테스트")
     void createHelloCallByGuard() {
         //given
-        Member member = mock(Member.class);
         Long memberId = 1L;
         Senior senior = mock(Senior.class);
         List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
@@ -79,11 +73,9 @@ public class HelloCallServiceTest {
         }
         timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now().plusHours(1), LocalTime.now().plusHours(1)));
         HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(10), timeSlots, 1000, 10, "testRequirement");
-        Point point = new Point(2000, member);
 
         when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
         when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
-        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.of(point));
 
         //when
         helloCallService.createHelloCallByGuard(memberId, helloCallRequest);
@@ -91,14 +83,12 @@ public class HelloCallServiceTest {
         //then
         verify(helloCallRepository, times(1)).save(any(HelloCall.class));
         verify(timeSlotRepository, times(helloCallRequest.timeSlots().size())).save(any(TimeSlot.class));
-        verify(pointLogRepository, times(1)).save(any(PointLog.class));
     }
 
     @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 시니어를 찾을 수 없을 때")
     void createHelloCallByGuardWhenSeniorIsNull() {
         //given
-        Member member = mock(Member.class);
         Long memberId = 1L;
         Senior senior = mock(Senior.class);
         List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
@@ -115,13 +105,11 @@ public class HelloCallServiceTest {
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 안부 전화 서비스가 존재할 때")
     void createHelloCallByGuardWhenHelloCallAlreadyExists() {
         //given
-        Member member = mock(Member.class);
         Long memberId = 1L;
         Senior senior = mock(Senior.class);
         List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
         timeSlots.add(new HelloCallRequest.TimeSlot("월", LocalTime.now(), LocalTime.now().plusHours(2)));
         HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
-        Point point = new Point(2000, member);
 
         when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
         when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(true);
@@ -131,43 +119,9 @@ public class HelloCallServiceTest {
     }
 
     @Test
-    @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 조회 실패할 때")
-    void createHelloCallByGuardWhenPointIsNotExist() {
-        //given
-        Member member = mock(Member.class);
-        Long memberId = 1L;
-        Senior senior = mock(Senior.class);
-        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
-
-        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
-        String dayName = "";
-
-        switch (dayOfWeek) {
-            case DayOfWeek.MONDAY -> dayName = "월";
-            case DayOfWeek.TUESDAY -> dayName = "화";
-            case DayOfWeek.WEDNESDAY -> dayName = "수";
-            case DayOfWeek.THURSDAY -> dayName = "목";
-            case DayOfWeek.FRIDAY -> dayName = "금";
-            case DayOfWeek.SATURDAY -> dayName = "토";
-            case DayOfWeek.SUNDAY -> dayName = "일";
-        }
-
-        timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now().plusHours(1), LocalTime.now().plusHours(2)));
-        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
-
-        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
-        when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
-        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.empty());
-
-        //when, then
-        assertThrows(NotFoundException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
-    }
-
-    @Test
     @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 부족할 때")
     void createHelloCallByGuardWhenPointIsLessThanPrice() {
         //given
-        Member member = mock(Member.class);
         Long memberId = 1L;
         Senior senior = mock(Senior.class);
         List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
@@ -185,11 +139,9 @@ public class HelloCallServiceTest {
         }
         timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now(), LocalTime.now().plusHours(2)));
         HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
-        Point point = new Point(100, member);
 
         when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
         when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
-        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.of(point));
 
         //when, then
         assertThrows(BadRequestException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
@@ -314,17 +266,14 @@ public class HelloCallServiceTest {
         Senior senior = new Senior("testSeniorName", "01012345678", member);
         HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
         Long helloCallId = 2L;
-        Point point = new Point(1000, member);
 
         when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.of(point));
 
         //when
         helloCallService.deleteHellCallByGuard(memberId, helloCallId);
 
         //then
-        verify(pointLogRepository, times(1)).save(any(PointLog.class));
         verify(helloCallRepository, times(1)).delete(any(HelloCall.class));
     }
 
@@ -353,24 +302,6 @@ public class HelloCallServiceTest {
 
         when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
-
-        //when, then
-        assertThrows(NotFoundException.class, () -> helloCallService.deleteHellCallByGuard(memberId, helloCallId));
-    }
-
-    @Test
-    @DisplayName("deleteHellCallByGuard 메소드 테스트 - 포인트를 조회할 수 없을 때")
-    void deleteHellCallByGuardTestWhenPointIsNotExist() {
-        //given
-        Member member = mock(Member.class);
-        Long memberId = 1L;
-        Senior senior = new Senior("testSeniorName", "01012345678", member);
-        HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
-        Long helloCallId = 2L;
-
-        when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(pointRepository.findByMemberIdWithWriteLock(memberId)).thenReturn(Optional.empty());
 
         //when, then
         assertThrows(NotFoundException.class, () -> helloCallService.deleteHellCallByGuard(memberId, helloCallId));
@@ -521,17 +452,15 @@ public class HelloCallServiceTest {
         helloCall.setMember(sinitto);
         helloCall.changeStatusToInProgress();
         helloCall.changeStatusToPendingComplete();
-        Point sinittoPoint = mock(Point.class);
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
-        when(pointRepository.findByMember(helloCall.getMember())).thenReturn(Optional.of(sinittoPoint));
 
         //when
         helloCallService.makeCompleteHelloCallByGuard(memberId, helloCallId);
 
         // then
-        verify(pointLogRepository, times(1)).save(any(PointLog.class));
+        verify(pointService, atLeastOnce()).earnPoint(anyLong(), anyInt(), any(PointLog.Content.class));
     }
 
     @Test
@@ -719,7 +648,6 @@ public class HelloCallServiceTest {
         HelloCall helloCall = new HelloCall(LocalDate.now(), LocalDate.now().plusDays(7), 500, 10, "testRequirement", senior);
         Long helloCallId = 2L;
         helloCall.setMember(sinitto);
-        Optional<HelloCallTimeLog> recentLog = Optional.of(new HelloCallTimeLog(mock(HelloCall.class), sinitto, LocalDateTime.now(), null));
 
         when(helloCallRepository.findById(helloCallId)).thenReturn(Optional.of(helloCall));
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());

--- a/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
@@ -119,35 +119,6 @@ public class HelloCallServiceTest {
     }
 
     @Test
-    @DisplayName("createHelloCallByGuard 메소드 테스트 - 포인트 부족할 때")
-    void createHelloCallByGuardWhenPointIsLessThanPrice() {
-        //given
-        Long memberId = 1L;
-        Senior senior = mock(Senior.class);
-        List<HelloCallRequest.TimeSlot> timeSlots = new ArrayList<>();
-        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
-        String dayName = "";
-
-        switch (dayOfWeek) {
-            case DayOfWeek.MONDAY -> dayName = "월";
-            case DayOfWeek.TUESDAY -> dayName = "화";
-            case DayOfWeek.WEDNESDAY -> dayName = "수";
-            case DayOfWeek.THURSDAY -> dayName = "목";
-            case DayOfWeek.FRIDAY -> dayName = "금";
-            case DayOfWeek.SATURDAY -> dayName = "토";
-            case DayOfWeek.SUNDAY -> dayName = "일";
-        }
-        timeSlots.add(new HelloCallRequest.TimeSlot(dayName, LocalTime.now(), LocalTime.now().plusHours(2)));
-        HelloCallRequest helloCallRequest = new HelloCallRequest(senior.getId(), LocalDate.now(), LocalDate.now().plusDays(7), timeSlots, 1000, 10, "testRequirement");
-
-        when(seniorRepository.findByIdAndMemberId(helloCallRequest.seniorId(), memberId)).thenReturn(Optional.of(senior));
-        when(helloCallRepository.existsBySeniorAndStatusIn(senior, List.of(HelloCall.Status.WAITING, HelloCall.Status.IN_PROGRESS))).thenReturn(false);
-
-        //when, then
-        assertThrows(BadRequestException.class, () -> helloCallService.createHelloCallByGuard(memberId, helloCallRequest));
-    }
-
-    @Test
     @DisplayName("readAllHelloCallsByGuard 메소드 테스트")
     void readAllHelloCallsByGuardTest() {
         //given


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#115 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 포인트관련 로직을 포인트 서비스계층으로 통합
    - 콜백과 안부전화에서 포인트 관련 로직을 포인트 서비스 계층으로 옮겼습니다
- 스케쥴되는 메서드에서 콜백 상태 변환에 개별 트랜잭션 적용하였습니다.
    - 기존에는 트랜잭션이 길어질 가능성이 존재했는데 이제 개별 트랜잭션 적용으로 이 부분 해소 
    - !!! 그런데 이렇게 하면 DB I/O 가 많아지는 단점이 있을거 같긴합니다...혹시 의견있으시면 주시면 좋겠습니담.
- 콜백 테스트 코드 추가 및 가독성 개선
    - `@Nested` 를 써서 테스트 코드 파악이 더 쉽게 해보았습니다
    - 콜백 도메인에서 테스트 못한 것들 모두 추가완료 하였습니다.
- 콜백 서비스에서 불필요한 private 메서드 통합 
- 사소히 변경된것들
    - 메서드 명 변경 
    - `@Transactional(readOnly = true)` 추가
- 10분마다 완료대기상태가 2일 지난 콜백 완료로 자동전환해주는 로직의 SQL 수정

findAllByStatusAndPendingCompleteTimeBefore ->findAllByStatusAndPendingCompleteTimeBetween
```sql
Hibernate: 
    select
        c1_0.id,
        c1_0.assigned_member_id,
        c1_0.pending_complete_time,
        c1_0.post_time,
        c1_0.senior_id,
        c1_0.status 
    from
        callback c1_0 
    where
        c1_0.status=? 
        and c1_0.pending_complete_time between ? and ?
```
### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #115 