### PR TITLE
Fix, Refactor : refreshToken 만료 시 InvalidJwtException 반환하도록 변경, accessToken의 만료 시간 수정

### DIFF
--- a/src/main/java/com/example/sinitto/auth/service/KakaoTokenService.java
+++ b/src/main/java/com/example/sinitto/auth/service/KakaoTokenService.java
@@ -3,8 +3,8 @@ package com.example.sinitto.auth.service;
 import com.example.sinitto.auth.dto.KakaoTokenResponse;
 import com.example.sinitto.auth.entity.KakaoToken;
 import com.example.sinitto.auth.repository.KakaoTokenRepository;
+import com.example.sinitto.common.exception.InvalidJwtException;
 import com.example.sinitto.common.exception.NotFoundException;
-import com.example.sinitto.common.exception.UnauthorizedException;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +40,7 @@ public class KakaoTokenService {
 
         if (kakaoToken.isAccessTokenExpired()) {
             if (kakaoToken.isRefreshTokenExpired()) {
-                throw new UnauthorizedException("카카오 리프레쉬 토큰이 만료되었습니다. 카카오 재 로그인 필요");
+                throw new InvalidJwtException("카카오 리프레쉬 토큰이 만료되었습니다. 카카오 재 로그인 필요");
             }
             KakaoTokenResponse kakaoTokenResponse = kakaoApiService.refreshAccessToken(kakaoToken.getRefreshToken());
             kakaoToken.updateKakaoToken(kakaoTokenResponse.accessToken(), kakaoTokenResponse.refreshToken(), kakaoTokenResponse.expiresIn(), kakaoTokenResponse.refreshTokenExpiresIn());

--- a/src/main/java/com/example/sinitto/auth/service/TokenService.java
+++ b/src/main/java/com/example/sinitto/auth/service/TokenService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class TokenService {
 
-    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 60 * 10;
+    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 5;
     private static final long REFRESH_SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7;
 
     private final Key secretKey;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #138 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- refreshToken 만료 시 InvalidJwtException 반환하도록 변경
- accessToken의 만료 시간 수정

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #138 
> 
