### PR TITLE
Refactor: 포인트 도메인 운영코드 개선과 테스트코드 개선 및 추가

### DIFF
--- a/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
+++ b/src/main/java/com/example/sinitto/point/controller/PointAdminController.java
@@ -1,11 +1,7 @@
 package com.example.sinitto.point.controller;
 
-import com.example.sinitto.common.exception.NotFoundException;
-import com.example.sinitto.member.entity.Member;
-import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointLogWithBankInfo;
 import com.example.sinitto.point.dto.PointLogWithDepositMessage;
-import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.service.PointAdminService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -13,40 +9,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Controller
 public class PointAdminController {
 
     private final PointAdminService pointAdminService;
-    private final MemberRepository memberRepository;
 
-    public PointAdminController(PointAdminService pointAdminService, MemberRepository memberRepository) {
+    public PointAdminController(PointAdminService pointAdminService) {
         this.pointAdminService = pointAdminService;
-        this.memberRepository = memberRepository;
     }
 
     @GetMapping("/admin/point/charge")
     public String showAllChargeRequest(Model model) {
 
-        List<PointLog> pointLogs = pointAdminService.readAllNotCompletedPointChargeRequest();
-        List<PointLogWithDepositMessage> logWithDepositMessages = new ArrayList<>();
+        List<PointLogWithDepositMessage> logWithDepositMessages = pointAdminService.getPointLogWithDepositMessage();
 
-        for (PointLog pointLog : pointLogs) {
-            Member member = memberRepository.findById(pointLog.getMember().getId())
-                    .orElseThrow(() -> new NotFoundException("멤버를 찾을 수 없습니다"));
-
-            PointLogWithDepositMessage pointLogWithDepositMessage = new PointLogWithDepositMessage(
-                    pointLog.getId(),
-                    pointLog.getPrice(),
-                    pointLog.getPostTime(),
-                    pointLog.getStatus(),
-                    member.getDepositMessage()
-            );
-
-            logWithDepositMessages.add(pointLogWithDepositMessage);
-        }
         model.addAttribute("logWithDepositMessages", logWithDepositMessages);
 
         return "point/charge";

--- a/src/main/java/com/example/sinitto/point/dto/PointLogWithBankInfo.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogWithBankInfo.java
@@ -2,12 +2,10 @@ package com.example.sinitto.point.dto;
 
 import com.example.sinitto.point.entity.PointLog;
 
-import java.time.LocalDateTime;
-
 public record PointLogWithBankInfo(
         Long pointLogId,
         int price,
-        LocalDateTime postTime,
+        String postTime,
         PointLog.Status status,
         String bankName,
         String bankAccountNumber

--- a/src/main/java/com/example/sinitto/point/dto/PointLogWithDepositMessage.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogWithDepositMessage.java
@@ -2,12 +2,10 @@ package com.example.sinitto.point.dto;
 
 import com.example.sinitto.point.entity.PointLog;
 
-import java.time.LocalDateTime;
-
 public record PointLogWithDepositMessage(
         Long pointLogId,
         int price,
-        LocalDateTime postTime,
+        String postTime,
         PointLog.Status status,
         String depositMessage
 ) {

--- a/src/main/java/com/example/sinitto/point/entity/PointLog.java
+++ b/src/main/java/com/example/sinitto/point/entity/PointLog.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class PointLog {
 
+    public static final double WITHDRAWAL_FEE_RATE = 0.8;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -92,6 +94,10 @@ public class PointLog {
         if (this.status != wantStatus) {
             throw new ConflictException(String.format("현재 %s 상태입니다. 이 상태에서는 %s 로의 전환이 불가합니다.", this.status, wantStatus));
         }
+    }
+
+    public int getPointPriceAfterFee() {
+        return (int) (price * WITHDRAWAL_FEE_RATE);
     }
 
     public Long getId() {

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -14,6 +14,7 @@ import com.example.sinitto.sinitto.repository.SinittoBankInfoRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +46,7 @@ public class PointAdminService {
             PointLogWithDepositMessage pointLogWithDepositMessage = new PointLogWithDepositMessage(
                     pointLog.getId(),
                     pointLog.getPrice(),
-                    pointLog.getPostTime(),
+                    pointLog.getPostTime().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")),
                     pointLog.getStatus(),
                     member.getDepositMessage()
             );
@@ -132,7 +133,7 @@ public class PointAdminService {
             PointLogWithBankInfo pointLogWithBankInfo = new PointLogWithBankInfo(
                     pointLog.getId(),
                     pointLog.getPointPriceAfterFee(),
-                    pointLog.getPostTime(),
+                    pointLog.getPostTime().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")),
                     pointLog.getStatus(),
                     sinittoBankInfo.getBankName(),
                     sinittoBankInfo.getAccountNumber()

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -1,7 +1,10 @@
 package com.example.sinitto.point.service;
 
 import com.example.sinitto.common.exception.NotFoundException;
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointLogWithBankInfo;
+import com.example.sinitto.point.dto.PointLogWithDepositMessage;
 import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.repository.PointLogRepository;
@@ -20,16 +23,36 @@ public class PointAdminService {
     private final PointLogRepository pointLogRepository;
     private final PointRepository pointRepository;
     private final SinittoBankInfoRepository sinittoBankInfoRepository;
+    private final MemberRepository memberRepository;
 
-    public PointAdminService(PointLogRepository pointLogRepository, PointRepository pointRepository, SinittoBankInfoRepository sinittoBankInfoRepository) {
+    public PointAdminService(PointLogRepository pointLogRepository, PointRepository pointRepository, SinittoBankInfoRepository sinittoBankInfoRepository, MemberRepository memberRepository) {
         this.pointLogRepository = pointLogRepository;
         this.pointRepository = pointRepository;
         this.sinittoBankInfoRepository = sinittoBankInfoRepository;
+        this.memberRepository = memberRepository;
     }
 
-    public List<PointLog> readAllNotCompletedPointChargeRequest() {
+    @Transactional(readOnly = true)
+    public List<PointLogWithDepositMessage> getPointLogWithDepositMessage() {
 
-        return pointLogRepository.findAllByStatusInOrderByPostTimeDesc(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST, PointLog.Status.CHARGE_COMPLETE, PointLog.Status.CHARGE_FAIL));
+        List<PointLog> pointLogs = pointLogRepository.findAllByStatusInOrderByPostTimeDesc(List.of(PointLog.Status.CHARGE_WAITING, PointLog.Status.CHARGE_REQUEST, PointLog.Status.CHARGE_COMPLETE, PointLog.Status.CHARGE_FAIL));
+        List<PointLogWithDepositMessage> logWithDepositMessages = new ArrayList<>();
+
+        for (PointLog pointLog : pointLogs) {
+            Member member = memberRepository.findById(pointLog.getMember().getId())
+                    .orElse(new Member("미등록 유저", "미등록 유저", "미등록 유저", false));
+
+            PointLogWithDepositMessage pointLogWithDepositMessage = new PointLogWithDepositMessage(
+                    pointLog.getId(),
+                    pointLog.getPrice(),
+                    pointLog.getPostTime(),
+                    pointLog.getStatus(),
+                    member.getDepositMessage()
+            );
+
+            logWithDepositMessages.add(pointLogWithDepositMessage);
+        }
+        return logWithDepositMessages;
     }
 
     @Transactional

--- a/src/main/java/com/example/sinitto/point/service/PointAdminService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointAdminService.java
@@ -131,7 +131,7 @@ public class PointAdminService {
 
             PointLogWithBankInfo pointLogWithBankInfo = new PointLogWithBankInfo(
                     pointLog.getId(),
-                    pointLog.getPrice(),
+                    pointLog.getPointPriceAfterFee(),
                     pointLog.getPostTime(),
                     pointLog.getStatus(),
                     sinittoBankInfo.getBankName(),

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class PointService {
 
-    public static final double WITHDRAWAL_FEE_RATE = 0.8;
     private final MemberRepository memberRepository;
     private final PointRepository pointRepository;
     private final PointLogRepository pointLogRepository;
@@ -34,6 +33,7 @@ public class PointService {
         this.sinittoBankInfoRepository = sinittoBankInfoRepository;
     }
 
+    @Transactional(readOnly = true)
     public PointResponse getPoint(Long memberId) {
 
         Member member = memberRepository.findById(memberId)
@@ -45,6 +45,7 @@ public class PointService {
         return new PointResponse(point.getPrice());
     }
 
+    @Transactional(readOnly = true)
     public Page<PointLogResponse> getPointLogs(Long memberId, Pageable pageable) {
 
         Member member = memberRepository.findById(memberId)
@@ -87,14 +88,12 @@ public class PointService {
         Point point = pointRepository.findByMember(member)
                 .orElseThrow(() -> new NotFoundException("요청한 멤버의 포인트를 찾을 수 없습니다"));
 
-        int adjustedPrice = (int) (price * WITHDRAWAL_FEE_RATE);
-
         if (!point.isSufficientForDeduction(price)) {
             throw new BadRequestException(String.format("보유한 포인트(%d) 보다 더 많은 포인트에 대한 출금요청입니다", point.getPrice()));
         }
 
         point.deduct(price);
 
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST.getMessage(), member, adjustedPrice, PointLog.Status.WITHDRAW_REQUEST));
+        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST.getMessage(), member, price, PointLog.Status.WITHDRAW_REQUEST));
     }
 }

--- a/src/main/resources/static/css/point.css
+++ b/src/main/resources/static/css/point.css
@@ -1,61 +1,86 @@
 body {
     font-family: Arial, sans-serif;
-    background-color: #f4f4f4;
+    background-color: #e9edf0;
     margin: 0;
     padding: 20px;
+    color: #333;
 }
 
 h1 {
     text-align: center;
     color: #333;
+    font-weight: 600;
+    margin-bottom: 30px;
 }
 
 table {
+
     width: 100%;
     border-collapse: collapse;
     margin: 20px 0;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+    border-radius: 8px;
+    overflow: hidden;
 }
 
 th, td {
-    padding: 12px;
-    text-align: left;
-    border: 1px solid #ddd;
-    background-color: #fff;
+    padding: 16px;
+    text-align: center;
+    border-bottom: 1px solid #e1e4e8;
 }
 
 th {
-    background-color: #4CAF50;
-    color: white;
+    background-color: rgba(52, 87, 217, 0.8);
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 16px;
+    top: 0;
+}
+
+td {
+    font-size: 14px;
+    color: #555;
 }
 
 tr:nth-child(even) {
-    background-color: #f9f9f9;
-}
-
-tr:hover {
-    background-color: #f1f1f1;
+    background-color: #f7f9fb;
 }
 
 button {
-    background-color: #4CAF50;
-    color: white;
+    background-color: rgba(52, 87, 217, 0.8);
+    color: #ffffff;
     border: none;
-    padding: 10px 15px;
-    text-align: center;
-    text-decoration: none;
-    display: inline-block;
+    padding: 10px 20px;
     font-size: 14px;
-    margin: 4px 2px;
     cursor: pointer;
     border-radius: 4px;
-    transition: background-color 0.3s;
+    transition: background-color 0.3s, transform 0.2s;
 }
 
 button:hover {
-    background-color: #45a049;
+    background-color: rgba(52, 87, 217, 0.93);
+    transform: scale(1.03);
+}
+
+button:active {
+    background-color: #00473c;
 }
 
 form {
     display: inline;
+    margin: 0;
+}
+
+.header {
+    background-color: #00796b;
+    padding: 20px;
+    color: #ffffff;
+    border-radius: 8px;
+    margin-bottom: 30px;
+}
+
+.header h1 {
+    margin: 0;
+    font-size: 24px;
 }

--- a/src/main/resources/templates/point/charge.html
+++ b/src/main/resources/templates/point/charge.html
@@ -41,7 +41,7 @@
                 <form method="post"
                       th:action="@{/admin/point/charge/complete/{pointLogId}(pointLogId=${logWithDepositMessage.pointLogId})}"
                       th:if="${logWithDepositMessage.status.toString()} == 'CHARGE_WAITING'">
-                    <button type="submit">포인트 지급 & 완료 상태로 변경</button>
+                    <button type="submit">완료 상태로 변경</button>
                 </form>
 
                 <!-- 상태가 CHARGE_WAITING일 때 -->

--- a/src/main/resources/templates/point/charge.html
+++ b/src/main/resources/templates/point/charge.html
@@ -6,6 +6,11 @@
     <title>충전 페이지</title>
 </head>
 <body>
+
+<div>
+    <h1>포인트 충전 관리</h1>
+</div>
+
 <div>
     <table>
         <thead>

--- a/src/main/resources/templates/point/withdraw.html
+++ b/src/main/resources/templates/point/withdraw.html
@@ -6,12 +6,17 @@
     <title>출금 페이지</title>
 </head>
 <body>
+
+<div>
+    <h1>포인트 출금 관리</h1>
+</div>
+
 <div>
     <table>
         <thead>
         <tr>
-            <th>출금 요청시간</th>
-            <th>출금 포인트</th>
+            <th>요청 시간</th>
+            <th>수수료 적용 된 출금 포인트</th>
             <th>은행 이름</th>
             <th>계좌번호</th>
             <th>상태</th>

--- a/src/main/resources/templates/point/withdraw.html
+++ b/src/main/resources/templates/point/withdraw.html
@@ -43,7 +43,7 @@
                 <form method="post"
                       th:action="@{/admin/point/withdraw/complete/{pointLogId}(pointLogId=${logWithBankInfo.pointLogId()})}"
                       th:if="${logWithBankInfo.status().toString()} == 'WITHDRAW_WAITING'">
-                    <button type="submit">입금 완료 & 완료 상태로 변경</button>
+                    <button type="submit">완료 상태로 변경</button>
                 </form>
 
                 <!-- 상태가 CHARGE_WAITING일 때 -->

--- a/src/test/java/com/example/sinitto/point/service/PointAdminServiceTest.java
+++ b/src/test/java/com/example/sinitto/point/service/PointAdminServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,6 +53,7 @@ class PointAdminServiceTest {
             Member member = mock(Member.class);
             when(pointLogRepository.findAllByStatusInOrderByPostTimeDesc(anyList())).thenReturn(List.of(pointLog));
             when(pointLog.getMember()).thenReturn(member);
+            when(pointLog.getPostTime()).thenReturn(LocalDateTime.now());
             when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
             when(member.getDepositMessage()).thenReturn("DepositMessage");
 
@@ -173,7 +175,8 @@ class PointAdminServiceTest {
             when(sinittoBankInfoRepository.findByMemberId(anyLong())).thenReturn(Optional.of(sinittoBankInfo));
 
             when(pointLog.getMember()).thenReturn(mock(Member.class));
-            when(pointLog.getPrice()).thenReturn(5050);
+            when(pointLog.getPointPriceAfterFee()).thenReturn(5050);
+            when(pointLog.getPostTime()).thenReturn(LocalDateTime.now());
             when(sinittoBankInfo.getBankName()).thenReturn("BankName");
             when(sinittoBankInfo.getAccountNumber()).thenReturn("AccountNumber");
 

--- a/src/test/java/com/example/sinitto/point/service/PointAdminServiceTest.java
+++ b/src/test/java/com/example/sinitto/point/service/PointAdminServiceTest.java
@@ -1,0 +1,191 @@
+package com.example.sinitto.point.service;
+
+import com.example.sinitto.member.entity.Member;
+import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointLogWithBankInfo;
+import com.example.sinitto.point.dto.PointLogWithDepositMessage;
+import com.example.sinitto.point.entity.Point;
+import com.example.sinitto.point.entity.PointLog;
+import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
+import com.example.sinitto.sinitto.entity.SinittoBankInfo;
+import com.example.sinitto.sinitto.repository.SinittoBankInfoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@MockitoSettings
+class PointAdminServiceTest {
+
+    @Mock
+    private PointLogRepository pointLogRepository;
+    @Mock
+    private PointRepository pointRepository;
+    @Mock
+    private SinittoBankInfoRepository sinittoBankInfoRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @InjectMocks
+    private PointAdminService pointAdminService;
+
+    @Nested
+    @DisplayName("포인트 충전에 관한 관리자 페이지 테스트")
+    class PointChargeAdminPageTest {
+
+        @Test
+        @DisplayName("포인트 충전 로그와 입금메시지 조회에 성공한다.")
+        void getPointLogWithDepositMessage() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            Member member = mock(Member.class);
+            when(pointLogRepository.findAllByStatusInOrderByPostTimeDesc(anyList())).thenReturn(List.of(pointLog));
+            when(pointLog.getMember()).thenReturn(member);
+            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+            when(member.getDepositMessage()).thenReturn("DepositMessage");
+
+            // when
+            List<PointLogWithDepositMessage> result = pointAdminService.getPointLogWithDepositMessage();
+
+            // then
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals("DepositMessage", result.getFirst().depositMessage());
+        }
+
+        @Test
+        @DisplayName("충전 요청 상태인 것을 충전 대기 상태로 전환시킨다.")
+        void changeChargeLogToWaiting() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            when(pointLogRepository.findById(anyLong())).thenReturn(Optional.of(pointLog));
+
+            // when
+            pointAdminService.changeChargeLogToWaiting(1L);
+
+            // then
+            verify(pointLog).changeStatusToChargeWaiting();
+        }
+
+        @Test
+        @DisplayName("충전 대기 상태인 것을 충전 완료 상태로 전환시킨다. 이때, 이것을 수행한 시니또에게 포인트가 동시에 적립이 된다.")
+        void earnPointAndChangeToChargeComplete() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            Point point = mock(Point.class);
+            Member member = mock(Member.class);
+            when(pointLog.getMember()).thenReturn(member);
+            when(pointLogRepository.findById(anyLong())).thenReturn(Optional.of(pointLog));
+            when(pointRepository.findByMember(pointLog.getMember())).thenReturn(Optional.of(point));
+
+            // when
+            pointAdminService.earnPointAndChangeToChargeComplete(1L);
+
+            // then
+            verify(pointLog).changeStatusToChargeComplete();
+            verify(point).earn(anyInt());
+        }
+
+        @Test
+        @DisplayName("어떤 이유에 의해서 시니또가 한 충전 요청을 실패 표시한다.")
+        void changeChargeLogToFail() {
+            // Given
+            PointLog pointLog = mock(PointLog.class);
+            when(pointLogRepository.findById(anyLong())).thenReturn(Optional.of(pointLog));
+
+            // When
+            pointAdminService.changeChargeLogToFail(1L);
+
+            // Then
+            verify(pointLog).changeStatusToChargeFail();
+        }
+
+    }
+
+    @Nested
+    @DisplayName("포인트 출금에 관한 관리자 페이지 테스트")
+    class PointWithdrawAdminPageTest {
+
+        @Test
+        @DisplayName("출금 요청 상태인 것을 출금 대기 상태로 전환시킨다.")
+        void changeWithdrawLogToWaiting() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            when(pointLogRepository.findById(anyLong())).thenReturn(Optional.of(pointLog));
+
+            // when
+            pointAdminService.changeWithdrawLogToWaiting(1L);
+
+            // then
+            verify(pointLog).changeStatusToWithdrawWaiting();
+        }
+
+        @Test
+        @DisplayName("출금 대기 상태인 것을 출금 완료 상태로 전환시킨다.")
+        void changeWithdrawLogToComplete() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            when(pointLogRepository.findById(anyLong())).thenReturn(Optional.of(pointLog));
+
+            // when
+            pointAdminService.changeWithdrawLogToComplete(1L);
+
+            // then
+            verify(pointLog).changeStatusToWithdrawComplete();
+        }
+
+        @Test
+        @DisplayName("어떤 이유에 의해서 시니또의 출금 요청을 실패 상태로 전환시킨다. 동시에 시니또에게 포인트를 돌려준다.")
+        void changeWithdrawLogToFail() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            Point point = mock(Point.class);
+            when(pointLogRepository.findById(anyLong())).thenReturn(Optional.of(pointLog));
+            when(pointRepository.findByMember(pointLog.getMember())).thenReturn(Optional.of(point));
+
+            // when
+            pointAdminService.changeWithdrawLogToFail(1L);
+
+            // then
+            verify(pointLog).changeStatusToWithdrawFail();
+            verify(point).earn(anyInt());
+        }
+
+        @Test
+        @DisplayName("출금 로그와 시니또의 은행 정보 조회에 성공한다.")
+        void getPointLogWithBankInfo() {
+            // given
+            PointLog pointLog = mock(PointLog.class);
+            SinittoBankInfo sinittoBankInfo = mock(SinittoBankInfo.class);
+
+            when(pointLogRepository.findAllByStatusInOrderByPostTimeDesc(anyList())).thenReturn(List.of(pointLog));
+            when(sinittoBankInfoRepository.findByMemberId(anyLong())).thenReturn(Optional.of(sinittoBankInfo));
+
+            when(pointLog.getMember()).thenReturn(mock(Member.class));
+            when(pointLog.getPrice()).thenReturn(5050);
+            when(sinittoBankInfo.getBankName()).thenReturn("BankName");
+            when(sinittoBankInfo.getAccountNumber()).thenReturn("AccountNumber");
+
+            // when
+            List<PointLogWithBankInfo> result = pointAdminService.getPointLogWithBankInfo();
+
+            // then
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals(5050, result.getFirst().price());
+            assertEquals("BankName", result.getFirst().bankName());
+            assertEquals("AccountNumber", result.getFirst().bankAccountNumber());
+        }
+    }
+}

--- a/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
+++ b/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
@@ -1,26 +1,33 @@
 package com.example.sinitto.point.service;
 
+import com.example.sinitto.common.exception.BadRequestException;
+import com.example.sinitto.common.exception.ForbiddenException;
+import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
+import com.example.sinitto.point.dto.PointChargeResponse;
 import com.example.sinitto.point.dto.PointLogResponse;
+import com.example.sinitto.point.dto.PointResponse;
+import com.example.sinitto.point.entity.Point;
 import com.example.sinitto.point.entity.PointLog;
 import com.example.sinitto.point.repository.PointLogRepository;
+import com.example.sinitto.point.repository.PointRepository;
+import com.example.sinitto.sinitto.repository.SinittoBankInfoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @MockitoSettings
 class PointServiceTest {
@@ -29,32 +36,193 @@ class PointServiceTest {
     MemberRepository memberRepository;
     @Mock
     PointLogRepository pointLogRepository;
+    @Mock
+    PointRepository pointRepository;
+    @Mock
+    SinittoBankInfoRepository sinittoBankInfoRepository;
     @InjectMocks
     PointService pointService;
 
-    @Test
-    void getPointLogs() {
-        //given
-        Long memberId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        Member member = mock(Member.class);
-        PointLog pointLog = mock(PointLog.class);
+    @Nested
+    @DisplayName("포인트 조회 테스트")
+    class GetPointTest {
 
-        when(pointLog.getContent()).thenReturn("content");
-        when(pointLog.getPrice()).thenReturn(10000);
-        when(pointLog.getStatus()).thenReturn(PointLog.Status.EARN);
+        @Test
+        @DisplayName("포인트 조회 성공한다.")
+        void getPoint1() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 
-        Page<PointLog> pointLogPage = new PageImpl<>(List.of(pointLog));
+            Point point = mock(Point.class);
+            when(pointRepository.findByMember(member)).thenReturn(Optional.of(point));
 
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(pointLogRepository.findAllByMember(member, pageable)).thenReturn(pointLogPage);
+            //when
+            PointResponse result = pointService.getPoint(1L);
 
-        //when
-        Page<PointLogResponse> result = pointService.getPointLogs(memberId, pageable);
+            //then
+            assertInstanceOf(PointResponse.class, result);
+        }
 
-        //then
-        assertNotNull(result);
-        assertEquals(1, result.getTotalElements());
-        assertEquals(PointLog.Status.EARN, result.getContent().getFirst().status());
+        @Test
+        @DisplayName("우리 멤버가 아닌 사람이 요청시 예외를 발생시켜야한다.")
+        void getPoint2() {
+            //given
+            when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+            //when then
+            assertThrows(NotFoundException.class, () -> pointService.getPoint(1L));
+        }
+
+        @Test
+        @DisplayName("우리 멤버는 맞지만 연관된 포인트 엔티티가 없으면 예외를 발생시켜야한다.")
+        void getPoint3() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+            when(pointRepository.findByMember(member)).thenReturn(Optional.empty());
+
+            //when then
+            assertThrows(NotFoundException.class, () -> pointService.getPoint(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 로그 조회 테스트")
+    class GetPointLogTest {
+
+        @Test
+        @DisplayName("포인트 로그 조회 성공한다.")
+        void getPointLogs1() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+            PointLog pointLog = mock(PointLog.class);
+            when(pointLog.getContent()).thenReturn("content");
+            when(pointLog.getPrice()).thenReturn(10000);
+            when(pointLog.getStatus()).thenReturn(PointLog.Status.EARN);
+
+            when(pointLogRepository.findAllByMember(member, Pageable.ofSize(1))).thenReturn(new PageImpl<>(List.of(pointLog)));
+
+            //when
+            Page<PointLogResponse> result = pointService.getPointLogs(1L, Pageable.ofSize(1));
+
+            //then
+            assertNotNull(result);
+            assertEquals(PointLog.Status.EARN, result.getContent().getFirst().status());
+
+        }
+
+        @Test
+        @DisplayName("포인트 로그 요청을 우리 멤버가 아닌 사람이하면 예외를 발생시켜야한다.")
+        void getPointLogs2() {
+            //given
+            Long memberId = 1L;
+            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            //when then
+            assertThrows(NotFoundException.class, () -> pointService.getPointLogs(memberId, Pageable.ofSize(1)));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("포인트 충전 테스트")
+    class SavePointTest {
+
+        @Test
+        @DisplayName("포인트 충전 요청 성공한다.")
+        void savePointChargeRequest1() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+            //when
+            PointChargeResponse result = pointService.savePointChargeRequest(1L, 10000);
+
+            //then
+            verify(pointLogRepository).save(any(PointLog.class));
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("포인트 충전 요청시 멤버가 존재하지 않으면 예외를 발생시켜야한다.")
+        void savePointChargeRequest2() {
+            //given
+            when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+            //when then
+            assertThrows(NotFoundException.class, () -> pointService.savePointChargeRequest(1L, 10000));
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 출금 테스트")
+    class WithdrawPointTest {
+
+        @Test
+        @DisplayName("포인트 출금 요청 성공한다.")
+        void savePointWithdrawRequest1() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(sinittoBankInfoRepository.existsByMemberId(1L)).thenReturn(true);
+
+            Point point = mock(Point.class);
+            when(pointRepository.findByMember(member)).thenReturn(Optional.of(point));
+            when(point.isSufficientForDeduction(10000)).thenReturn(true);
+
+            //when
+            pointService.savePointWithdrawRequest(1L, 10000);
+
+            //then
+            verify(point).deduct(10000);
+            verify(pointLogRepository).save(any(PointLog.class));
+        }
+
+        @Test
+        @DisplayName("시니또가 아닌 멤버가 출금 요청시 예외를 발생시켜야한다.")
+        void savePointWithdrawRequest2() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(false);
+
+            //when then
+            assertThrows(ForbiddenException.class, () -> pointService.savePointWithdrawRequest(1L, 10000));
+        }
+
+        @Test
+        @DisplayName("시니또의 은행 계좌 정보가 없으면 예외를 발생시켜야한다.")
+        void savePointWithdrawRequest3() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(sinittoBankInfoRepository.existsByMemberId(1L)).thenReturn(false);
+
+            //when then
+            assertThrows(NotFoundException.class, () -> pointService.savePointWithdrawRequest(1L, 10000));
+        }
+
+        @Test
+        @DisplayName("포인트가 충분하지 않으면 예외를 발생시켜야한다.")
+        void savePointWithdrawRequest4() {
+            //given
+            Member member = mock(Member.class);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+            when(member.isSinitto()).thenReturn(true);
+            when(sinittoBankInfoRepository.existsByMemberId(1L)).thenReturn(true);
+
+            Point point = mock(Point.class);
+            when(pointRepository.findByMember(member)).thenReturn(Optional.of(point));
+            when(point.isSufficientForDeduction(10000)).thenReturn(false);
+
+            //when then
+            assertThrows(BadRequestException.class, () -> pointService.savePointWithdrawRequest(1L, 10000));
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#137

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 관리자 페이지 표 이름 수정
- PointAdminService (포인트 관리자 서비스계층) 테스트 추가
- 미흡했던 PointService 테스트 개선 및 추기
- 관리자 페이지에서 요청시간 표시 개선
    - 기존: `2024-11-03T15:38:54.916219`
    - 변경: `yyyy년 MM월 dd일 HH시 mm분`
- 기존 관리자 페이지 CSS 가 좀 그래서 수정해봤는데 약간 나아진거 같아요 ㅜ 감각 좋으신분 수정 대환영입니다
- 기존에 출금 요청을 한 포인트 로그에 수수료가 적용된걸로 로그로 생성되어 프론트 페이지에서 신청한 출금액과 다른 액수가 표시됨
    - 예) 시니또는 5000원을 출금 요청했는데 보이는 출금 요청 로그는 4000원이 되어있음 
    - <img width="372" alt="SCR-20241103-oarh" src="https://github.com/user-attachments/assets/78844532-d412-439f-aeb9-204c175cd2c5">  << 5000원 출금요청했는데 4000원이 표시되는 모습
     - 그래서 요청 로그에는 출금 액수 그대로 나오도록 수정하고, 관리자 페이지에서는 수수료가 적용된 금액으로 나오게 수정하였습니다.

### 스크린샷 (선택)

<img width="1440" alt="SCR-20241103-nwww" src="https://github.com/user-attachments/assets/5cbd1897-93f2-48b2-acf2-7de2fe6972bf">

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #137 
