### PR TITLE
feat, hotfix : 회원탈퇴 api 추가 및 redisTemplate 수정

### DIFF
--- a/src/main/java/com/example/sinitto/member/controller/MemberController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberController.java
@@ -44,4 +44,10 @@ public class MemberController {
         memberService.memberLogout(memberId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "멤버 회원탈퇴", description = "회원 정보를 삭제합니다.")
+    public ResponseEntity<Void> deleteMember(@MemberId Long memberId) {
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/sinitto/member/controller/MemberController.java
+++ b/src/main/java/com/example/sinitto/member/controller/MemberController.java
@@ -46,6 +46,7 @@ public class MemberController {
     }
 
     @Operation(summary = "멤버 회원탈퇴", description = "회원 정보를 삭제합니다.")
+    @DeleteMapping("/withdrawal")
     public ResponseEntity<Void> deleteMember(@MemberId Long memberId) {
         memberService.deleteMember(memberId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/sinitto/member/service/MemberService.java
+++ b/src/main/java/com/example/sinitto/member/service/MemberService.java
@@ -28,9 +28,9 @@ public class MemberService implements MemberIdProvider {
     private final KakaoApiService kakaoApiService;
     private final KakaoTokenService kakaoTokenService;
     private final PointRepository pointRepository;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
-    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, RedisTemplate<String, String> redisTemplate) {
+    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, RedisTemplate<String, Object> redisTemplate) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
         this.kakaoApiService = kakaoApiService;
@@ -90,10 +90,23 @@ public class MemberService implements MemberIdProvider {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 멤버가 없습니다."));
 
-        String storedRefreshToken = redisTemplate.opsForValue().get(member.getEmail());
+        String storedRefreshToken = (String) redisTemplate.opsForHash().get(member.getEmail(), "refreshToken");
 
         if (storedRefreshToken != null) {
             redisTemplate.delete(member.getEmail());
         }
+    }
+
+    public void deleteMember(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("id에 해당하는 멤버가 없습니다."));
+
+        String storedRefreshToken = (String) redisTemplate.opsForHash().get(member.getEmail(), "refreshToken");
+
+        if (storedRefreshToken != null) {
+            redisTemplate.delete(member.getEmail());
+        }
+
+        memberRepository.deleteById(memberId);
     }
 }

--- a/src/test/java/com/example/sinitto/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/example/sinitto/auth/service/TokenServiceTest.java
@@ -1,19 +1,14 @@
 package com.example.sinitto.auth.service;
 
-import com.example.sinitto.common.exception.InvalidJwtException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoSettings;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 
-import javax.crypto.spec.SecretKeySpec;
-import java.security.Key;
 import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,10 +17,10 @@ import static org.mockito.Mockito.*;
 @MockitoSettings
 public class TokenServiceTest {
     @Mock
-    private RedisTemplate<String, String> redisTemplate;
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Mock
-    private ValueOperations<String, String> valueOperations;
+    private HashOperations<String, Object, Object> hashOperations;
 
     private TokenService tokenService;
 
@@ -60,7 +55,7 @@ public class TokenServiceTest {
         //given
         String email = "test@email.com";
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
 
         //when
         String token = tokenService.generateRefreshToken(email);

--- a/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.Optional;
 
@@ -31,9 +31,9 @@ public class MemberServiceTest {
     @Mock
     TokenService tokenService;
     @Mock
-    RedisTemplate<String, String> redisTemplate;
+    RedisTemplate<String, Object> redisTemplate;
     @Mock
-    private ValueOperations<String, String> valueOperations;
+    private HashOperations<String, Object, Object> hashOperations;
     @InjectMocks
     MemberService memberService;
 
@@ -61,7 +61,6 @@ public class MemberServiceTest {
         //given
         String token = "testtoken";
         String email = "test@email.com";
-        Member member = mock(Member.class);
 
         when(tokenService.extractEmailFromAccessToken(token)).thenReturn(email);
         when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
@@ -110,12 +109,14 @@ public class MemberServiceTest {
     void memberLogoutTest() {
         //given
         Long memberId = 1L;
+        String email = "test@email.com";
         Member member = mock(Member.class);
         String storedRefreshToken = "testRefreshToken";
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(redisTemplate.opsForValue().get(member.getEmail())).thenReturn(storedRefreshToken);
+        when(member.getEmail()).thenReturn(email);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(redisTemplate.opsForHash().get(member.getEmail(), "refreshToken")).thenReturn(storedRefreshToken);
         //when
         memberService.memberLogout(memberId);
 
@@ -135,5 +136,26 @@ public class MemberServiceTest {
 
         //when, then
         assertThrows(NotFoundException.class, () -> memberService.memberLogout(memberId));
+    }
+
+    @Test
+    @DisplayName("deleteMember 메소드 테스트")
+    void deleteMemberTest(){
+        //given
+        Long memberId = 1L;
+        String email = "test@email.com";
+        Member member = mock(Member.class);
+        String storedRefreshToken = "testRefreshToken";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(member.getEmail()).thenReturn(email);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(redisTemplate.opsForHash().get(member.getEmail(), "refreshToken")).thenReturn(storedRefreshToken);
+
+        //when
+        memberService.deleteMember(memberId);
+
+        //when
+        verify(memberRepository, times(1)).deleteById(memberId);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #169 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 회원 탈퇴 api 구현 (DELETE /api/members/withdrawal)
- 로그아웃 및 회원 탈퇴 로직에 redisTemplate이 포함되어있어 수정
- 테스트 코드 수정

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 
