### PR TITLE
HotFix: 로그아웃 시 멤버가 없으면 로그아웃 안되는 에러 해결

### DIFF
--- a/src/main/java/com/example/sinitto/member/service/MemberService.java
+++ b/src/main/java/com/example/sinitto/member/service/MemberService.java
@@ -88,7 +88,11 @@ public class MemberService implements MemberIdProvider {
 
     public void memberLogout(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException("id에 해당하는 멤버가 없습니다."));
+                .orElseThrow(null);
+
+        if (member == null) {
+            return;
+        }
 
         String storedRefreshToken = (String) redisTemplate.opsForHash().get(member.getEmail(), "refreshToken");
 

--- a/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
@@ -138,7 +138,7 @@ public class MemberServiceTest {
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
         //when, then
-        assertThrows(NotFoundException.class, () -> memberService.memberLogout(memberId));
+        assertThrows(NullPointerException.class, () -> memberService.memberLogout(memberId));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #177 

## 📝 작업 내용
- HotFix: 로그아웃 시 멤버가 없으면 로그아웃 안되는 에러 해결

## ⏰ 현재 버그
없습니다

## ✏ Git Close
close #177 
