### PR TITLE
Feat: 시니또 탈퇴 본인이 할당받은 서비스가 있으면 다시 대기상태로 전환되는 로직 추가

### DIFF
--- a/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
+++ b/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
@@ -1,7 +1,6 @@
 package com.example.sinitto.callback.repository;
 
 import com.example.sinitto.callback.entity.Callback;
-import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,8 +15,6 @@ public interface CallbackRepository extends JpaRepository<Callback, Long> {
     Page<Callback> findAllByStatus(Callback.Status status, Pageable pageable);
 
     Optional<Callback> findByAssignedMemberIdAndStatus(Long memberId, Callback.Status status);
-
-    Optional<Callback> findByAssignedMemberAndStatus(Member member, Callback.Status status);
 
     boolean existsByAssignedMemberIdAndStatus(Long memberId, Callback.Status status);
 

--- a/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
+++ b/src/main/java/com/example/sinitto/callback/repository/CallbackRepository.java
@@ -1,6 +1,7 @@
 package com.example.sinitto.callback.repository;
 
 import com.example.sinitto.callback.entity.Callback;
+import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.entity.Senior;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,8 @@ public interface CallbackRepository extends JpaRepository<Callback, Long> {
     Page<Callback> findAllByStatus(Callback.Status status, Pageable pageable);
 
     Optional<Callback> findByAssignedMemberIdAndStatus(Long memberId, Callback.Status status);
+
+    Optional<Callback> findByAssignedMemberAndStatus(Member member, Callback.Status status);
 
     boolean existsByAssignedMemberIdAndStatus(Long memberId, Callback.Status status);
 

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -110,7 +111,7 @@ public class CallbackService {
         }
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void completeCallbackIndividually(Callback callback) {
 
         pointService.earnPoint(callback.getAssignedMemberId(), CALLBACK_PRICE, PointLog.Content.COMPLETE_CALLBACK_AND_EARN);

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -219,4 +219,16 @@ public class CallbackService {
         return new CallbackForSinittoResponse(callback.getId(), callback.getSeniorName(), callback.getPostTime(), callback.getStatus(), callback.getSeniorId(), false, "");
     }
 
+    @Transactional
+    public void cancelAssignedCallbackIfInProgress(Member member) {
+
+        Callback callback = callbackRepository.findByAssignedMemberAndStatus(member, Callback.Status.IN_PROGRESS)
+                .orElse(null);
+
+        if (callback != null) {
+            callback.cancelAssignment();
+            callback.changeStatusToWaiting();
+        }
+    }
+
 }

--- a/src/main/java/com/example/sinitto/callback/service/CallbackService.java
+++ b/src/main/java/com/example/sinitto/callback/service/CallbackService.java
@@ -222,7 +222,7 @@ public class CallbackService {
     @Transactional
     public void cancelAssignedCallbackIfInProgress(Member member) {
 
-        Callback callback = callbackRepository.findByAssignedMemberAndStatus(member, Callback.Status.IN_PROGRESS)
+        Callback callback = callbackRepository.findByAssignedMemberIdAndStatus(member.getId(), Callback.Status.IN_PROGRESS)
                 .orElse(null);
 
         if (callback != null) {

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCall.java
@@ -43,6 +43,7 @@ public class HelloCall {
     private List<TimeSlot> timeSlots = new ArrayList<>();
     @ManyToOne
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member member;
     @OneToMany(mappedBy = "helloCall")
     private List<HelloCallTimeLog> helloCallTimeLogs = new ArrayList<>();

--- a/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
+++ b/src/main/java/com/example/sinitto/helloCall/entity/HelloCallTimeLog.java
@@ -20,7 +20,7 @@ public class HelloCallTimeLog {
     @JoinColumn(name = "helloCall_id")
     private HelloCall helloCall;
     @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     @JoinColumn(name = "sinitto_id")
     private Member member;
 
@@ -56,6 +56,9 @@ public class HelloCallTimeLog {
     }
 
     public String getSinittoName() {
+        if (member == null) {
+            return "탈퇴한 시니또";
+        }
         return this.member.getName();
     }
 

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
@@ -19,4 +19,6 @@ public interface HelloCallRepository extends JpaRepository<HelloCall, Long> {
     List<HelloCall> findAllBySeniorIn(List<Senior> seniors);
 
     boolean existsBySeniorAndStatusIn(Senior senior, List<HelloCall.Status> statuses);
+
+    Optional<HelloCall> findByMemberAndStatus(Member member, HelloCall.Status status);
 }

--- a/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
+++ b/src/main/java/com/example/sinitto/helloCall/repository/HelloCallRepository.java
@@ -20,5 +20,5 @@ public interface HelloCallRepository extends JpaRepository<HelloCall, Long> {
 
     boolean existsBySeniorAndStatusIn(Senior senior, List<HelloCall.Status> statuses);
 
-    Optional<HelloCall> findByMemberAndStatus(Member member, HelloCall.Status status);
+    List<HelloCall> findByMemberAndStatus(Member member, HelloCall.Status status);
 }

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -323,10 +323,9 @@ public class HelloCallService {
     @Transactional
     public void cancelAssignedHelloCallIfInProgress(Member member) {
 
-        HelloCall helloCall = helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)
-                .orElse(null);
+        List<HelloCall> helloCalls = helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS);
 
-        if (helloCall != null) {
+        for (HelloCall helloCall : helloCalls) {
             helloCall.changeStatusToWaiting();
             helloCall.setMember(null);
         }

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -325,6 +326,11 @@ public class HelloCallService {
 
         List<HelloCall> helloCalls = helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS);
 
+        changeHelloCall(helloCalls);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void changeHelloCall(List<HelloCall> helloCalls) {
         for (HelloCall helloCall : helloCalls) {
             helloCall.changeStatusToWaiting();
             helloCall.setMember(null);

--- a/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
+++ b/src/main/java/com/example/sinitto/helloCall/service/HelloCallService.java
@@ -320,4 +320,16 @@ public class HelloCallService {
         return helloCallResponses;
     }
 
+    @Transactional
+    public void cancelAssignedHelloCallIfInProgress(Member member) {
+
+        HelloCall helloCall = helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)
+                .orElse(null);
+
+        if (helloCall != null) {
+            helloCall.changeStatusToWaiting();
+            helloCall.setMember(null);
+        }
+    }
+
 }

--- a/src/main/java/com/example/sinitto/member/service/MemberService.java
+++ b/src/main/java/com/example/sinitto/member/service/MemberService.java
@@ -6,9 +6,11 @@ import com.example.sinitto.auth.dto.LoginResponse;
 import com.example.sinitto.auth.service.KakaoApiService;
 import com.example.sinitto.auth.service.KakaoTokenService;
 import com.example.sinitto.auth.service.TokenService;
+import com.example.sinitto.callback.service.CallbackService;
 import com.example.sinitto.common.exception.ConflictException;
 import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.common.resolver.MemberIdProvider;
+import com.example.sinitto.helloCall.service.HelloCallService;
 import com.example.sinitto.member.dto.RegisterResponse;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
@@ -29,14 +31,18 @@ public class MemberService implements MemberIdProvider {
     private final KakaoTokenService kakaoTokenService;
     private final PointRepository pointRepository;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final CallbackService callbackService;
+    private final HelloCallService helloCallService;
 
-    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, RedisTemplate<String, Object> redisTemplate) {
+    public MemberService(MemberRepository memberRepository, TokenService tokenService, KakaoApiService kakaoApiService, KakaoTokenService kakaoTokenService, PointRepository pointRepository, RedisTemplate<String, Object> redisTemplate, CallbackService callbackService, HelloCallService helloCallService) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
         this.kakaoApiService = kakaoApiService;
         this.kakaoTokenService = kakaoTokenService;
         this.pointRepository = pointRepository;
         this.redisTemplate = redisTemplate;
+        this.callbackService = callbackService;
+        this.helloCallService = helloCallService;
     }
 
     @Override
@@ -101,7 +107,7 @@ public class MemberService implements MemberIdProvider {
         }
     }
 
-    public void deleteMember(Long memberId){
+    public void deleteMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 멤버가 없습니다."));
 
@@ -111,6 +117,12 @@ public class MemberService implements MemberIdProvider {
             redisTemplate.delete(member.getEmail());
         }
 
+        if (member.isSinitto()) {
+            callbackService.cancelAssignedCallbackIfInProgress(member);
+            helloCallService.cancelAssignedHelloCallIfInProgress(member);
+        }
+
         memberRepository.deleteById(memberId);
     }
 }
+

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -529,4 +529,43 @@ class CallbackServiceTest {
             assertEquals("", result.seniorPhoneNumber());
         }
     }
+
+    @Nested
+    @DisplayName("시니또가 탈퇴시 진행중인 콜백이 있으면 취소시키는 로직 테스트")
+    class CancelAssignedCallbackIfInProgress {
+
+        @Test
+        @DisplayName("진행중인 콜백이 있으면, 콜백을 대기상태로 전환시켜야한다.")
+        void cancelAssignedCallbackIfInProgress1() {
+            //given
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+
+            when(callbackRepository.findByAssignedMemberAndStatus(any(Member.class), any(Callback.Status.class))).thenReturn(Optional.of(callback));
+
+            //when
+            callbackService.cancelAssignedCallbackIfInProgress(member);
+
+            //then
+            verify(callback, atLeastOnce()).cancelAssignment();
+            verify(callback, atLeastOnce()).changeStatusToWaiting();
+        }
+
+        @Test
+        @DisplayName("진행중인 콜백이 없으면, 아무것도 하지 않아야한다.")
+        void cancelAssignedCallbackIfInProgress2() {
+            //given
+            Member member = mock(Member.class);
+            Callback callback = mock(Callback.class);
+
+            when(callbackRepository.findByAssignedMemberAndStatus(any(Member.class), any(Callback.Status.class))).thenReturn(Optional.empty());
+
+            //when
+            callbackService.cancelAssignedCallbackIfInProgress(member);
+
+            //then
+            verify(callback, never()).cancelAssignment();
+            verify(callback, never()).changeStatusToWaiting();
+        }
+    }
 }

--- a/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
+++ b/src/test/java/com/example/sinitto/callback/service/CallbackServiceTest.java
@@ -541,7 +541,7 @@ class CallbackServiceTest {
             Member member = mock(Member.class);
             Callback callback = mock(Callback.class);
 
-            when(callbackRepository.findByAssignedMemberAndStatus(any(Member.class), any(Callback.Status.class))).thenReturn(Optional.of(callback));
+            when(callbackRepository.findByAssignedMemberIdAndStatus(anyLong(), any(Callback.Status.class))).thenReturn(Optional.of(callback));
 
             //when
             callbackService.cancelAssignedCallbackIfInProgress(member);
@@ -558,7 +558,7 @@ class CallbackServiceTest {
             Member member = mock(Member.class);
             Callback callback = mock(Callback.class);
 
-            when(callbackRepository.findByAssignedMemberAndStatus(any(Member.class), any(Callback.Status.class))).thenReturn(Optional.empty());
+            when(callbackRepository.findByAssignedMemberIdAndStatus(anyLong(), any(Callback.Status.class))).thenReturn(Optional.empty());
 
             //when
             callbackService.cancelAssignedCallbackIfInProgress(member);

--- a/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
@@ -872,14 +872,14 @@ public class HelloCallServiceTest {
         Member member = mock(Member.class);
         HelloCall helloCall = mock(HelloCall.class);
 
-        when(helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)).thenReturn(Optional.of(helloCall));
+        when(helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)).thenReturn(List.of(helloCall));
 
         // when
         helloCallService.cancelAssignedHelloCallIfInProgress(member);
 
         // then
-        verify(helloCall, atLeastOnce()).changeStatusToWaiting();
-        verify(helloCall, atLeastOnce()).setMember(null);
+        verify(helloCall, times(1)).changeStatusToWaiting();
+        verify(helloCall, times(1)).setMember(null);
     }
 
     @Test
@@ -889,7 +889,7 @@ public class HelloCallServiceTest {
         Member member = mock(Member.class);
         HelloCall helloCall = mock(HelloCall.class);
 
-        when(helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)).thenReturn(Optional.empty());
+        when(helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)).thenReturn(List.of());
 
         // when
         helloCallService.cancelAssignedHelloCallIfInProgress(member);

--- a/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
+++ b/src/test/java/com/example/sinitto/hellocall/service/HelloCallServiceTest.java
@@ -864,4 +864,39 @@ public class HelloCallServiceTest {
         //when, then
         assertThrows(NotFoundException.class, () -> helloCallService.readOwnHelloCallBySinitto(memberId));
     }
+
+    @Test
+    @DisplayName("시니또 탈퇴시 할당받은 안부전화가 있으면 안부전화 엔티티를 대기상태로 바꾸고, 멤버도 null 로 교체한다.")
+    void cancelAssignedHelloCallIfInProgressTest1() {
+        // given
+        Member member = mock(Member.class);
+        HelloCall helloCall = mock(HelloCall.class);
+
+        when(helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)).thenReturn(Optional.of(helloCall));
+
+        // when
+        helloCallService.cancelAssignedHelloCallIfInProgress(member);
+
+        // then
+        verify(helloCall, atLeastOnce()).changeStatusToWaiting();
+        verify(helloCall, atLeastOnce()).setMember(null);
+    }
+
+    @Test
+    @DisplayName("시니또 탈퇴시 할당받은 안부전화가 없으면 아무것도 하지 않는다.")
+    void cancelAssignedHelloCallIfInProgressTest2() {
+        // given
+        Member member = mock(Member.class);
+        HelloCall helloCall = mock(HelloCall.class);
+
+        when(helloCallRepository.findByMemberAndStatus(member, HelloCall.Status.IN_PROGRESS)).thenReturn(Optional.empty());
+
+        // when
+        helloCallService.cancelAssignedHelloCallIfInProgress(member);
+
+        // then
+        verify(helloCall, never()).changeStatusToWaiting();
+        verify(helloCall, never()).setMember(null);
+    }
+
 }

--- a/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/sinitto/member/service/MemberServiceTest.java
@@ -1,8 +1,10 @@
 package com.example.sinitto.member.service;
 
 import com.example.sinitto.auth.service.TokenService;
+import com.example.sinitto.callback.service.CallbackService;
 import com.example.sinitto.common.exception.ConflictException;
 import com.example.sinitto.common.exception.NotFoundException;
+import com.example.sinitto.helloCall.service.HelloCallService;
 import com.example.sinitto.member.dto.RegisterResponse;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
@@ -34,11 +36,16 @@ public class MemberServiceTest {
     @Mock
     RedisTemplate<String, Object> redisTemplate;
     @Mock
-    private HashOperations<String, Object, Object> hashOperations;
+    HashOperations<String, Object, Object> hashOperations;
     @InjectMocks
     MemberService memberService;
     @Mock
-    private ValueOperations<String, String> valueOperations;
+    ValueOperations<String, String> valueOperations;
+    @Mock
+    CallbackService callbackService;
+    @Mock
+    HelloCallService helloCallService;
+
 
     @Test
     @DisplayName("getMemberIdByToken 메소드 테스트")
@@ -143,7 +150,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("deleteMember 메소드 테스트")
-    void deleteMemberTest(){
+    void deleteMemberTest() {
         //given
         Long memberId = 1L;
         String email = "test@email.com";
@@ -160,5 +167,53 @@ public class MemberServiceTest {
 
         //when
         verify(memberRepository, times(1)).deleteById(memberId);
+    }
+
+    @Test
+    @DisplayName("deleteMember 메소드 테스트 - 탈퇴 신청한게 시니또인 경우")
+    void deleteMemberTest2() {
+        //given
+        Long memberId = 1L;
+        String email = "test@email.com";
+        Member member = mock(Member.class);
+        String storedRefreshToken = "testRefreshToken";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(member.getEmail()).thenReturn(email);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(redisTemplate.opsForHash().get(member.getEmail(), "refreshToken")).thenReturn(storedRefreshToken);
+
+        when(member.isSinitto()).thenReturn(true);
+        //when
+        memberService.deleteMember(memberId);
+
+        //when
+        verify(memberRepository, times(1)).deleteById(memberId);
+        verify(callbackService, times(1)).cancelAssignedCallbackIfInProgress(any(Member.class));
+        verify(helloCallService, times(1)).cancelAssignedHelloCallIfInProgress(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("deleteMember 메소드 테스트 - 탈퇴 신청한게 보호자인 경우")
+    void deleteMemberTest3() {
+        //given
+        Long memberId = 1L;
+        String email = "test@email.com";
+        Member member = mock(Member.class);
+        String storedRefreshToken = "testRefreshToken";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(member.getEmail()).thenReturn(email);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(redisTemplate.opsForHash().get(member.getEmail(), "refreshToken")).thenReturn(storedRefreshToken);
+
+        when(member.isSinitto()).thenReturn(false);
+        //when
+        memberService.deleteMember(memberId);
+
+        //when
+        verify(memberRepository, times(1)).deleteById(memberId);
+        verify(callbackService, times(0)).cancelAssignedCallbackIfInProgress(any(Member.class));
+        verify(helloCallService, times(0)).cancelAssignedHelloCallIfInProgress(any(Member.class));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#176


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 콜백 서비스층에 탈퇴시 들어가는 로직 구현
- 안부전화 서비스층에 탈퇴시 들어가는 로직 구현
- 멤버 탈퇴 로직에 콜백, 안부전화 진행중인거 확인하고 진행중인거 있으면 대기상태로 전환하는 로직 추가
- 새로 추가된 로직들에 대한 테스트 코드 추가
### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

안부전화는 여러개 동시에 진행이 되는것으로 확인하였습니다! 그래서 List를 사용했는데 확인 한번 부탁드려요~!

## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #176