### PR TITLE
HotFix: 시니어 정보 수정 시 전화번호를 수정하지 않고 다른 필드를 수정하면 전화번호 중복 오류가 뜨는 문제 해결

### DIFF
--- a/src/main/java/com/example/sinitto/guard/service/GuardService.java
+++ b/src/main/java/com/example/sinitto/guard/service/GuardService.java
@@ -90,7 +90,8 @@ public class GuardService {
                 () -> new NotFoundException("이메일에 해당하는 시니어를 찾을 수 없습니다.")
         );
 
-        if(seniorRepository.existsByPhoneNumber(seniorRequest.seniorPhoneNumber())) {
+        if(!senior.getPhoneNumber().equals(seniorRequest.seniorPhoneNumber())
+                && seniorRepository.existsByPhoneNumber(seniorRequest.seniorPhoneNumber())) {
             throw new BadRequestException("이미 등록되어 있는 전화번호 입니다.");
         }
 

--- a/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
+++ b/src/test/java/com/example/sinitto/guard/service/GuardServiceTest.java
@@ -184,6 +184,7 @@ public class GuardServiceTest {
         SeniorRequest request = new SeniorRequest("newSeniorName", "01011111111");
 
         when(seniorRepository.findByIdAndMemberId(seniorId, memberId)).thenReturn(Optional.of(senior));
+        when(senior.getPhoneNumber()).thenReturn("01012121212");
         //when
         guardService.updateSenior(memberId, seniorId, request);
 
@@ -203,6 +204,7 @@ public class GuardServiceTest {
 
         when(seniorRepository.findByIdAndMemberId(seniorId, memberId)).thenReturn(Optional.of(senior));
         when(seniorRepository.existsByPhoneNumber("01011111111")).thenReturn(true);
+        when(senior.getPhoneNumber()).thenReturn("01012121212");
         //when then
         assertThrows(BadRequestException.class, () -> guardService.updateSenior(memberId, seniorId, request));
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #182 

## 📝 작업 내용
- 시니어 정보 수정 시 전화번호를 수정하지 않고 다른 필드를 수정하면 전화번호 중복 오류가 뜨는 문제 해결

## ⏰ 현재 버그
없습니다

## ✏ Git Close
close #182 
