### PR TITLE
Deploy: 충전 및 출금 요청 발생시 슬랙메시지 전송 기능 추가

### DIFF
--- a/src/main/java/com/example/sinitto/common/service/SlackMessageService.java
+++ b/src/main/java/com/example/sinitto/common/service/SlackMessageService.java
@@ -14,13 +14,13 @@ import java.time.format.DateTimeFormatter;
 @Service
 public class SlackMessageService {
 
-    @Value("${slack.webhook.url}")
+    @Value("${slack.webhook.url:#{null}}}")
     private String slackWebhookUrl;
 
-    @Value("${slack.charge.request.url}")
+    @Value("${slack.charge.request.url:#{null}}}")
     private String chargeRequestUrl;
 
-    @Value("${slack.withdraw.request.url}")
+    @Value("${slack.withdraw.request.url:#{null}}}")
     private String withdrawRequestUrl;
 
     private final RestTemplate restTemplate;

--- a/src/main/java/com/example/sinitto/common/service/SlackMessageService.java
+++ b/src/main/java/com/example/sinitto/common/service/SlackMessageService.java
@@ -1,0 +1,69 @@
+package com.example.sinitto.common.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class SlackMessageService {
+
+    @Value("${slack.webhook.url}")
+    private String slackWebhookUrl;
+
+    @Value("${slack.charge.request.url}")
+    private String chargeRequestUrl;
+
+    @Value("${slack.withdraw.request.url}")
+    private String withdrawRequestUrl;
+
+    private final RestTemplate restTemplate;
+
+    public SlackMessageService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public void sendStyledSlackMessage(String title, String description, String actionType) {
+        String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        String actionUrl = actionType.equals("충전") ? chargeRequestUrl : withdrawRequestUrl;
+
+        String payload = String.format(
+                "{" +
+                        "\"blocks\": [" +
+                        "{" +
+                        "\"type\": \"section\"," +
+                        "\"block_id\": \"charge_request\"," +
+                        "\"text\": {" +
+                        "\"type\": \"mrkdwn\"," +
+                        "\"text\": \"*%s*\\n%s\\n*요청 시간:* %s\"" +
+                        "}," +
+                        "\"accessory\": {" +
+                        "\"type\": \"button\"," +
+                        "\"text\": {" +
+                        "\"type\": \"plain_text\"," +
+                        "\"text\": \"%s 요청\"" +
+                        "}," +
+                        "\"url\": \"%s\"," +
+                        "\"style\": \"%s\"" +
+                        "}" +
+                        "}" +
+                        "]" +
+                        "}",
+                title, description, currentTime, actionType, actionUrl, actionType.equals("충전") ? "primary" : "danger"
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+
+        restTemplate.exchange(slackWebhookUrl, HttpMethod.POST, entity, String.class);
+    }
+}

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -4,6 +4,7 @@ import com.example.sinitto.common.exception.BadRequestException;
 import com.example.sinitto.common.exception.ForbiddenException;
 import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.common.service.KakaoMessageService;
+import com.example.sinitto.common.service.SlackMessageService;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointChargeResponse;
@@ -28,13 +29,15 @@ public class PointService {
     private final PointLogRepository pointLogRepository;
     private final SinittoBankInfoRepository sinittoBankInfoRepository;
     private final KakaoMessageService kakaoMessageService;
+    private final SlackMessageService slackMessageService;
 
-    public PointService(MemberRepository memberRepository, PointRepository pointRepository, PointLogRepository pointLogRepository, SinittoBankInfoRepository sinittoBankInfoRepository, KakaoMessageService kakaoMessageService) {
+    public PointService(MemberRepository memberRepository, PointRepository pointRepository, PointLogRepository pointLogRepository, SinittoBankInfoRepository sinittoBankInfoRepository, KakaoMessageService kakaoMessageService, SlackMessageService slackMessageService) {
         this.memberRepository = memberRepository;
         this.pointRepository = pointRepository;
         this.pointLogRepository = pointLogRepository;
         this.sinittoBankInfoRepository = sinittoBankInfoRepository;
         this.kakaoMessageService = kakaoMessageService;
+        this.slackMessageService = slackMessageService;
     }
 
     @Transactional(readOnly = true)
@@ -74,6 +77,10 @@ public class PointService {
 
         kakaoMessageService.sendPointChargeRequestReceivedMessage(member.getEmail(), price, member.getName(), member.getDepositMessage());
 
+        String title = "포인트 충전 요청";
+        String description = String.format("%s님이 %d 포인트를 충전 요청했습니다.", member.getName(), price);
+        slackMessageService.sendStyledSlackMessage(title, description,"충전");
+
         return new PointChargeResponse(member.getDepositMessage());
     }
 
@@ -104,6 +111,11 @@ public class PointService {
 
         SinittoBankInfo sinittoBankInfo = sinittoBankInfoRepository.findByMemberId(memberId).orElseThrow(() -> new NotFoundException("시니또의 은행 계좌 정보가 없습니다."));
         kakaoMessageService.sendPointWithdrawRequestReceivedMessage(member.getEmail(), price, member.getName(), sinittoBankInfo.getBankName(), sinittoBankInfo.getAccountNumber());
+
+        String title = "포인트 출금 요청";
+        String description = String.format("%s님이 %d 포인트를 출금 요청했습니다.\n은행: %s, 계좌번호: %s",
+                member.getName(), price, sinittoBankInfo.getBankName(), sinittoBankInfo.getAccountNumber());
+        slackMessageService.sendStyledSlackMessage(title, description,"출금");
     }
 
     @Transactional

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,9 @@
+slack:
+  webhook:
+    url: "http://test/mock-slack-webhook"
+  charge:
+    request:
+      url: "http://test/mock-charge-request"
+  withdraw:
+    request:
+      url: "http://test/mock-withdraw-request"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,9 +1,0 @@
-slack:
-  webhook:
-    url: "http://test/mock-slack-webhook"
-  charge:
-    request:
-      url: "http://test/mock-charge-request"
-  withdraw:
-    request:
-      url: "http://test/mock-withdraw-request"

--- a/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
+++ b/src/test/java/com/example/sinitto/point/service/PointServiceTest.java
@@ -4,6 +4,7 @@ import com.example.sinitto.common.exception.BadRequestException;
 import com.example.sinitto.common.exception.ForbiddenException;
 import com.example.sinitto.common.exception.NotFoundException;
 import com.example.sinitto.common.service.KakaoMessageService;
+import com.example.sinitto.common.service.SlackMessageService;
 import com.example.sinitto.member.entity.Member;
 import com.example.sinitto.member.repository.MemberRepository;
 import com.example.sinitto.point.dto.PointChargeResponse;
@@ -46,6 +47,8 @@ class PointServiceTest {
     PointService pointService;
     @Mock
     KakaoMessageService kakaoMessageService;
+    @Mock
+    private SlackMessageService slackMessageService;
 
     @Nested
     @DisplayName("포인트 조회 테스트")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #189 

## 📝 작업 내용
- 충전 및 출금 요청 발생시 슬랙메시지 전송 기능 추가

### 스크린샷 (선택)
<img width="674" alt="image" src="https://github.com/user-attachments/assets/3f55bb84-debe-49bb-9fcb-7ec75c4f8e95">

## ⏰ 현재 버그
<img width="260" alt="image" src="https://github.com/user-attachments/assets/82d5758b-bbad-49f5-8a0e-00fa25e74763">
슬랙 설정 오류
기능 작동에는 문제 없습니다

## ✏ Git Close
close #189 
