### PR TITLE
HotFix: 포인트 로그 조회에서 content 는 `String` 으로 반환하도록 롤백

### DIFF
--- a/src/main/java/com/example/sinitto/point/dto/PointLogResponse.java
+++ b/src/main/java/com/example/sinitto/point/dto/PointLogResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 public record PointLogResponse(
         LocalDateTime postTime,
-        PointLog.Content content,
+        String content,
         int price,
         PointLog.Status status
 ) {

--- a/src/main/java/com/example/sinitto/point/service/PointService.java
+++ b/src/main/java/com/example/sinitto/point/service/PointService.java
@@ -66,7 +66,7 @@ public class PointService {
         return pointLogRepository.findAllByMember(member, pageable)
                 .map(pointLog -> new PointLogResponse(
                         pointLog.getPostTime(),
-                        pointLog.getContent(),
+                        pointLog.getContent().getMessage(),
                         pointLog.getPrice(),
                         pointLog.getStatus()
                 ));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#209 
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 포인트 로그 조회에서 content 는 `String` 으로 반환하도록 롤백

### 스크린샷 (선택)

![SCR-20241109-pibc](https://github.com/user-attachments/assets/d8ac4d27-4d96-41d1-8739-dfd442dc425e)
이걸 해결하기 위함
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #209 
