### PR TITLE
Fix: 포인트 로그관련 더미데이터 각 유저의 역할에 맞는 로그가 남도록 수정

### DIFF
--- a/src/main/java/com/example/sinitto/common/dummy/InitialData.java
+++ b/src/main/java/com/example/sinitto/common/dummy/InitialData.java
@@ -195,75 +195,45 @@ public class InitialData implements CommandLineRunner {
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard1, 50000, PointLog.Status.CHARGE_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard1, 50000, PointLog.Status.CHARGE_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard1, 50000, PointLog.Status.CHARGE_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, guard1, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, guard1, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, guard1, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, guard1, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, guard1, 50000, PointLog.Status.SPEND_CANCEL));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard1, 50000, PointLog.Status.WITHDRAW_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard1, 50000, PointLog.Status.WITHDRAW_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard1, 50000, PointLog.Status.WITHDRAW_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard1, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, guard2));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard2, 50000, PointLog.Status.CHARGE_FAIL));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard2, 50000, PointLog.Status.CHARGE_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard2, 50000, PointLog.Status.CHARGE_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard2, 50000, PointLog.Status.CHARGE_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, guard2, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, guard2, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, guard2, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, guard2, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, guard2, 50000, PointLog.Status.SPEND_CANCEL));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard2, 50000, PointLog.Status.WITHDRAW_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard2, 50000, PointLog.Status.WITHDRAW_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard2, 50000, PointLog.Status.WITHDRAW_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard2, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, guard3));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard3, 50000, PointLog.Status.CHARGE_FAIL));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard3, 50000, PointLog.Status.CHARGE_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard3, 50000, PointLog.Status.CHARGE_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard3, 50000, PointLog.Status.CHARGE_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, guard3, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, guard3, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, guard3, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, guard3, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, guard3, 50000, PointLog.Status.SPEND_CANCEL));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard3, 50000, PointLog.Status.WITHDRAW_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard3, 50000, PointLog.Status.WITHDRAW_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard3, 50000, PointLog.Status.WITHDRAW_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard3, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, guard4));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard4, 50000, PointLog.Status.CHARGE_FAIL));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard4, 50000, PointLog.Status.CHARGE_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard4, 50000, PointLog.Status.CHARGE_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard4, 50000, PointLog.Status.CHARGE_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, guard4, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, guard4, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, guard4, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, guard4, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, guard4, 50000, PointLog.Status.SPEND_CANCEL));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard4, 50000, PointLog.Status.WITHDRAW_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard4, 50000, PointLog.Status.WITHDRAW_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard4, 50000, PointLog.Status.WITHDRAW_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard4, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, guard5));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard5, 50000, PointLog.Status.CHARGE_FAIL));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard5, 50000, PointLog.Status.CHARGE_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard5, 50000, PointLog.Status.CHARGE_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, guard5, 50000, PointLog.Status.CHARGE_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, guard5, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, guard5, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, guard5, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, guard5, 50000, PointLog.Status.SPEND_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, guard5, 50000, PointLog.Status.SPEND_CANCEL));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard5, 50000, PointLog.Status.WITHDRAW_REQUEST));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard5, 50000, PointLog.Status.WITHDRAW_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard5, 50000, PointLog.Status.WITHDRAW_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, guard5, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         //콜백
         callbackRepository.save(new Callback(Callback.Status.COMPLETE, senior1));

--- a/src/main/java/com/example/sinitto/common/dummy/InitialData.java
+++ b/src/main/java/com/example/sinitto/common/dummy/InitialData.java
@@ -151,76 +151,40 @@ public class InitialData implements CommandLineRunner {
 
         //포인트와 포인트로그
         pointRepository.save(new Point(50000, memberSinitto1));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto1, 50000, PointLog.Status.CHARGE_FAIL));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto1, 50000, PointLog.Status.CHARGE_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto1, 50000, PointLog.Status.CHARGE_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto1, 50000, PointLog.Status.CHARGE_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, memberSinitto1, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, memberSinitto1, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, memberSinitto1, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, memberSinitto1, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, memberSinitto1, 50000, PointLog.Status.SPEND_CANCEL));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto1, 50000, PointLog.Status.WITHDRAW_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto1, 50000, PointLog.Status.WITHDRAW_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto1, 50000, PointLog.Status.WITHDRAW_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto1, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, memberSinitto2));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto2, 50000, PointLog.Status.CHARGE_FAIL));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto2, 50000, PointLog.Status.CHARGE_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto2, 50000, PointLog.Status.CHARGE_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto2, 50000, PointLog.Status.CHARGE_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, memberSinitto2, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, memberSinitto2, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, memberSinitto2, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, memberSinitto2, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, memberSinitto2, 50000, PointLog.Status.SPEND_CANCEL));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto2, 50000, PointLog.Status.WITHDRAW_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto2, 50000, PointLog.Status.WITHDRAW_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto2, 50000, PointLog.Status.WITHDRAW_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto2, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, memberSinitto3));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto3, 50000, PointLog.Status.CHARGE_FAIL));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto3, 50000, PointLog.Status.CHARGE_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto3, 50000, PointLog.Status.CHARGE_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto3, 50000, PointLog.Status.CHARGE_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, memberSinitto3, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, memberSinitto3, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, memberSinitto3, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, memberSinitto3, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, memberSinitto3, 50000, PointLog.Status.SPEND_CANCEL));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto3, 50000, PointLog.Status.WITHDRAW_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto3, 50000, PointLog.Status.WITHDRAW_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto3, 50000, PointLog.Status.WITHDRAW_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto3, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto3, 50000, PointLog.Status.CHARGE_COMPLETE));
 
         pointRepository.save(new Point(50000, memberSinitto4));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto4, 50000, PointLog.Status.CHARGE_FAIL));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto4, 50000, PointLog.Status.CHARGE_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto4, 50000, PointLog.Status.CHARGE_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto4, 50000, PointLog.Status.CHARGE_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, memberSinitto4, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, memberSinitto4, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, memberSinitto4, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, memberSinitto4, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, memberSinitto4, 50000, PointLog.Status.SPEND_CANCEL));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto4, 50000, PointLog.Status.WITHDRAW_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto4, 50000, PointLog.Status.WITHDRAW_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto4, 50000, PointLog.Status.WITHDRAW_COMPLETE));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto4, 50000, PointLog.Status.WITHDRAW_FAIL_AND_RESTORE_POINT));
 
         pointRepository.save(new Point(50000, memberSinitto5));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto5, 50000, PointLog.Status.CHARGE_FAIL));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto5, 50000, PointLog.Status.CHARGE_WAITING));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto5, 50000, PointLog.Status.CHARGE_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.CHARGE_REQUEST, memberSinitto5, 50000, PointLog.Status.CHARGE_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_CALLBACK_AND_EARN, memberSinitto5, 50000, PointLog.Status.EARN));
         pointLogRepository.save(new PointLog(PointLog.Content.COMPLETE_HELLO_CALL_AND_EARN, memberSinitto5, 50000, PointLog.Status.EARN));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_HELLO_CALL, memberSinitto5, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_COMPLETE_CALLBACK, memberSinitto5, 50000, PointLog.Status.SPEND_COMPLETE));
-        pointLogRepository.save(new PointLog(PointLog.Content.SPEND_CANCEL_HELLO_CALL, memberSinitto5, 50000, PointLog.Status.SPEND_CANCEL));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto5, 50000, PointLog.Status.WITHDRAW_REQUEST));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto5, 50000, PointLog.Status.WITHDRAW_WAITING));
         pointLogRepository.save(new PointLog(PointLog.Content.WITHDRAW_REQUEST, memberSinitto5, 50000, PointLog.Status.WITHDRAW_COMPLETE));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#229
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 포인트 로그관련 더미데이터 각 유저의 역할에 맞는 로그가 남도록 수정

## 시니또 관련 포인트로그 수정사항
- **충전** 요청 관련 로그 모두 제거
- **안부전화 요청**으로 인해 **포인트 차감** 로그 제거
- **콜백 요청**으로 인해 **포인트 차감** 로그 제거
## 보호자 관련 포인트로그 수정사항
- **출금** 요청 관련 로그 모두 제거
- **안부전화 요청 수행 완료**로 인한 **포인트 적립** 로그 제거
- **콜백 요청 수행 완료**로 인한 **포인트 적립** 로그 제거

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #이슈번호
> 

close #229 